### PR TITLE
Rtorrent за веб-сервером + аутентификация + учитывание порта

### DIFF
--- a/php/classes/rtorrent.php
+++ b/php/classes/rtorrent.php
@@ -6,7 +6,7 @@
  */
 class Rtorrent extends TorrentClient
 {
-    protected static $base = '%s://%s:%s/RPC2';
+    protected static $base = '%s://%s/RPC2';
 
     /**
      * получение имени сеанса
@@ -30,8 +30,11 @@ class Rtorrent extends TorrentClient
             'Content-type: text/xml',
             'Content-length: ' . strlen($request)
         );
+        if (!empty($this->port)) {
+            $this->host .= ':' . $this->port;
+        }
         curl_setopt_array($this->ch, array(
-            CURLOPT_URL => sprintf(self::$base, $this->scheme, $this->host, $this->port),
+            CURLOPT_URL => sprintf(self::$base, $this->scheme, $this->host),
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_HTTPHEADER => $header,
             CURLOPT_POSTFIELDS => $request

--- a/php/classes/rtorrent.php
+++ b/php/classes/rtorrent.php
@@ -36,7 +36,7 @@ class Rtorrent extends TorrentClient
             CURLOPT_HTTPHEADER => $header,
             CURLOPT_POSTFIELDS => $request
         ));
-        if (!empty($this->user)&&!empty($this->password){
+        if (!empty($this->user) && !empty($this->password){
             curl_setopt_array($this->ch, CURLOPT_USERPWD, $this->login . ':' . $this->password);
         }
         $maxNumberTry = 3;

--- a/php/classes/rtorrent.php
+++ b/php/classes/rtorrent.php
@@ -30,7 +30,7 @@ class Rtorrent extends TorrentClient
             'Content-type: text/xml',
             'Content-length: ' . strlen($request)
         );
-        if (!empty($this->port)) {
+        if (!empty($this->port) && !(strrpos($this->host, $this->port))) {
             $this->host .= ':' . $this->port;
         }
         curl_setopt_array($this->ch, array(

--- a/php/classes/rtorrent.php
+++ b/php/classes/rtorrent.php
@@ -6,7 +6,7 @@
  */
 class Rtorrent extends TorrentClient
 {
-    protected static $base = '%s://%s/RPC2';
+    protected static $base = '%s://%s:%s/RPC2';
 
     /**
      * получение имени сеанса
@@ -31,11 +31,14 @@ class Rtorrent extends TorrentClient
             'Content-length: ' . strlen($request)
         );
         curl_setopt_array($this->ch, array(
-            CURLOPT_URL => sprintf(self::$base, $this->scheme, $this->host),
+            CURLOPT_URL => sprintf(self::$base, $this->scheme, $this->host, $this->port),
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_HTTPHEADER => $header,
-            CURLOPT_POSTFIELDS => $request,
+            CURLOPT_POSTFIELDS => $request
         ));
+        if (!empty($this->user)&&!empty($this->password){
+            curl_setopt_array($this->ch, CURLOPT_USERPWD, $this->login . ':' . $this->password);
+        }
         $maxNumberTry = 3;
         $connectionNumberTry = 1;
         while (true) {

--- a/php/classes/rtorrent.php
+++ b/php/classes/rtorrent.php
@@ -37,8 +37,6 @@ class Rtorrent extends TorrentClient
             CURLOPT_URL => sprintf(self::$base, $this->scheme, $this->host),
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_HTTPHEADER => $header,
-			CURLOPT_SSL_VERIFYHOST => 0,
-			CURLOPT_SSL_VERIFYPEER => 0,
             CURLOPT_POSTFIELDS => $request
         ));
         if (!empty($this->login) && !empty($this->password)) {

--- a/php/classes/rtorrent.php
+++ b/php/classes/rtorrent.php
@@ -37,10 +37,12 @@ class Rtorrent extends TorrentClient
             CURLOPT_URL => sprintf(self::$base, $this->scheme, $this->host),
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_HTTPHEADER => $header,
+			CURLOPT_SSL_VERIFYHOST => 0,
+			CURLOPT_SSL_VERIFYPEER => 0,
             CURLOPT_POSTFIELDS => $request
         ));
-        if (!empty($this->user) && !empty($this->password){
-            curl_setopt_array($this->ch, CURLOPT_USERPWD, $this->login . ':' . $this->password);
+        if (!empty($this->login) && !empty($this->password)) {
+            curl_setopt($this->ch, CURLOPT_USERPWD, $this->login . ':' . $this->password);
         }
         $maxNumberTry = 3;
         $connectionNumberTry = 1;


### PR DESCRIPTION
### Что сделано:
Полноценно используем host/port/login/password переменные, всё так же обращаемся на /RPC2.
Изменение требует адаптации конфига на стороне пользователя:
Вместо "адрес_клиента:порт" в пункте "IP-адрес/сетевое имя", порт надо перенести в соответствующее поле

### Мотивация
/RPC2 теперь можно положить за веб-сервер, на котором и проводить аутентификацию, включая https подключение, и возможность скрыть /RPC2 куда-то вглубь веб-сервера, прописав в настройках клиента в WebTLO в параметре "порт" одновременно порт и путь в формате "port/custom/path/to" (/RPC2 добавляется сам).
Прятать /RPC2 за веб-сервер стоит потому, что XMLRPC rtorrent-а чрезвычайно опасен с точки зрения эксплуатации, как минимум за счёт команд execute.*
Веб-сервер можно настроить на обращение в unix-сокет, открываемый rtorrent'ом, с любыми желаемыми опциями конфигурации, включая, например, отдельно реализованный fail2ban.