### PR TITLE
Download torrent files with passkey replace

### DIFF
--- a/php/actions/get_torrent_files.php
+++ b/php/actions/get_torrent_files.php
@@ -106,9 +106,16 @@ try {
             }
             $trackers = $torrent->getTrackers();
             foreach ($trackers as &$tracker) {
-                $tracker = preg_replace('/(?<==)\w+$/', $cfg['user_passkey'], $tracker);
+                // Если задан пустой заменный ключ, то пихаем дефолтный 'ann?magnet'
+                if (empty($cfg['user_passkey'])) {
+                    $tracker = preg_replace('/(?<=ann\?).+$/', 'magnet', $tracker);
+                } else {
+                    $tracker = preg_replace('/(?<==)\w+$/', $cfg['user_passkey'], $tracker);
+                }
+
+                // Для обычных пользователей заменяем адрес трекера и тип ключа.
                 if ($cfg['tor_for_user']) {
-                    $tracker = preg_replace('/\w+(?==)/', 'pk', $tracker);
+                    $tracker = preg_replace(['/(?<=\.)([-\w]+\.\w+)/', '/\w+(?==)/'], ['t-ru.org', 'pk'], $tracker);
                 }
             }
             unset($tracker);

--- a/php/actions/get_torrent_files.php
+++ b/php/actions/get_torrent_files.php
@@ -83,11 +83,18 @@ try {
     // скачивание торрент-файлов
     $download = new TorrentDownload($cfg['forum_address']);
 
-    Log::append(
-        $replace_passkey
-            ? 'Выполняется скачивание торрент-файлов с заменой Passkey...'
-            : 'Выполняется скачивание торрент-файлов...'
+    $log_string = sprintf(
+        "Выполняется скачивание торрент-файлов (%d шт), трекеры %s. ",
+        count($topicHashes['topic_hashes']),
+        $cfg['tor_for_user'] ? 'пользовательские' : 'хранительские'
     );
+    if ($replace_passkey) {
+        $log_string .=
+            !empty($cfg['user_passkey'])
+                ? 'Замена Passkey: ' .$cfg['user_passkey']
+                : 'Passkey пуст.';
+    }
+    Log::append($log_string);
 
     // применяем таймауты
     $download->setUserConnectionOptions($cfg['curl_setopt']['forum']);


### PR DESCRIPTION
fix #153

If selected option `скачать торрент-файлы для обычного пользователя` tracker will be replaced with `t-ru.org`
If pressed button `Скачать *.torrent-файлы выделенных раздач текущего подраздела в каталог с заменой Passkey` and no passkey provided, then tracker will be replcaed with default.

Last commit provide some additional logs.

```
Замена пасскея для обычного пользователя:
27.12.2022 23:29:55 Выполняется скачивание торрент-файлов (2 шт), трекеры пользовательские.С заменой Passkey: asd123
27.12.2022 23:29:58 before => http://bt3.rutracker.net/ann?kk=real_key,after => http://bt3.t-ru.org/ann?pk=asd123
27.12.2022 23:30:00 before => http://bt2.rutracker.net/ann?kk=real_key,after => http://bt2.t-ru.org/ann?pk=asd123

Замена паскея для хранителя:
27.12.2022 23:30:24 Выполняется скачивание торрент-файлов (2 шт), трекеры хранительские.С заменой Passkey: asd123
27.12.2022 23:30:26 before => http://bt3.rutracker.net/ann?kk=real_key,after => http://bt3.rutracker.net/ann?kk=asd123
27.12.2022 23:30:28 before => http://bt2.rutracker.net/ann?kk=real_key,after => http://bt2.rutracker.net/ann?kk=asd123

Замена пасскея без указания оного:
27.12.2022 23:30:55 Выполняется скачивание торрент-файлов (2 шт), трекеры хранительские.С заменой Passkey:
27.12.2022 23:30:57 before => http://bt3.rutracker.net/ann?kk=real_key,after => http://bt3.rutracker.net/ann?magnet
27.12.2022 23:30:59 before => http://bt2.rutracker.net/ann?kk=real_key,after => http://bt2.rutracker.net/ann?magnet
```