### PR TITLE
Control keepers

### DIFF
--- a/index.php
+++ b/index.php
@@ -710,6 +710,11 @@ try {
                                 Останавливать раздачи с количеством пиров более:
                                 <input id="peers" name="peers" class="spinner-peers" type="text" size="2" value="<?php echo $cfg['topics_control']['peers'] ?>" />
                             </label>
+                            <label class="label" title="Укажите значение количества сидов-хранителей, которых не учитывать при подсчёте сидов. 0 - для выключения (по умолчанию: 3)">
+                                Не учитывать до
+                                <input id="keepers" name="keepers" class="spinner-keepers" type="text" size="1" value="<?php echo $cfg['topics_control']['keepers'] ?>" />
+                                сидирующих хранителей, при подсчете текущих сидов
+                            </label>
                             <label class="label" title="Установите, если необходимо регулировать раздачи, которые не попадают в хранимые разделы (по умолчанию: выключено)">
                                 <input name="unadded_subsections" type="checkbox" <?php echo $unadded_subsections ?> />
                                 регулировать раздачи не из хранимых подразделов

--- a/php/actions/set_config.php
+++ b/php/actions/set_config.php
@@ -61,6 +61,7 @@ try {
     ) {
         $ini->write('topics_control', 'peers', $cfg['peers']);
     }
+    $ini->write('topics_control', 'keepers', isset($cfg['keepers']) ? (int)$cfg['keepers'] : 0);
     $ini->write('topics_control', 'leechers', isset($cfg['leechers']) ? 1 : 0);
     $ini->write('topics_control', 'no_leechers', isset($cfg['no_leechers']) ? 1 : 0);
     $ini->write('topics_control', 'unadded_subsections', isset($cfg['unadded_subsections']) ? 1 : 0);

--- a/php/common.php
+++ b/php/common.php
@@ -112,6 +112,7 @@ function get_settings($filename = "")
 
     // регулировка раздач
     $config['topics_control']['peers'] = $ini->read('topics_control', 'peers', 10);
+    $config['topics_control']['keepers'] = $ini->read('topics_control', 'keepers', 3);
     $config['topics_control']['unadded_subsections'] = $ini->read('topics_control', 'unadded_subsections', 0);
     $config['topics_control']['leechers'] = $ini->read('topics_control', 'leechers', 0);
     $config['topics_control']['no_leechers'] = $ini->read('topics_control', 'no_leechers', 1);

--- a/php/common/control.php
+++ b/php/common/control.php
@@ -145,8 +145,15 @@ foreach ($cfg['clients'] as $torrentClientID => $torrentClientData) {
                     $topicData['seeders'] -= $topicData['seeders'] ? $torrentStatus : 0;
                     // находим значение личей
                     $leechers = $cfg['topics_control']['leechers'] ? $topicData['leechers'] : 0;
+                    // количество сидов-хранителей раздачи, которых нужно вычесть из счётчика
+                    $keepers = 0;
+                    if ($cfg['topics_control']['keepers'] > 0) {
+                        // хранители раздачи, исключая себя
+                        $keepers = count(array_diff($topicData['keepers'], [$cfg['user_id']]));
+                        $keepers = min($keepers, (int)$cfg['topics_control']['keepers']);
+                    }
                     // находим значение пиров
-                    $peers = $topicData['seeders'] + $leechers;
+                    $peers = $topicData['seeders'] + $leechers - $keepers;
                     // учитываем вновь прибывшего "лишнего" сида
                     if (
                         $topicData['seeders']

--- a/scripts/jquery.widgets.js
+++ b/scripts/jquery.widgets.js
@@ -100,6 +100,12 @@ $(document).ready(function () {
         max: 100,
         mouseWheel: true
     });
+    // регулировка раздач, количество хранителей
+    $(".spinner-keepers").spinner({
+        min: 0,
+        max: 10,
+        mouseWheel: true
+    });
 
     // инициализация "аккордиона" для вкладки настройки
     $("div.sub_settings").each(function () {


### PR DESCRIPTION
Added an option to exclude a specified number of active seeding keepers from the peer count while control.
![image](https://user-images.githubusercontent.com/54838254/210000541-7f4fe77a-86d0-4741-ae8b-9d417e853bb9.png)
0 - to disable feature. Default value:3

If the actual number of active keepers is greater than the setting value it will be used.

Added some temp logs:
```
29.12.2022 22:22:22 Получение данных о пирах...
29.12.2022 22:22:22 hash=> config:3 => forum_keepers:1 => calc_keepers:1 => seeders:3 => calc_peers:2
29.12.2022 22:22:22 Обработка раздач раздела 773 (1 шт) завершена за 0s, лимит сидов 8
29.12.2022 22:22:23 hash=> config:3 => forum_keepers:0 => calc_keepers:0 => seeders:50 => calc_peers:50
29.12.2022 22:22:23 hash=> config:3 => forum_keepers:0 => calc_keepers:0 => seeders:84 => calc_peers:84
29.12.2022 22:22:23 Обработка раздач раздела 1605 (2 шт) завершена за 0s, лимит сидов 10
29.12.2022 22:22:24 hash=> config:3 => forum_keepers:3 => calc_keepers:3 => seeders:33 => calc_peers:30
```
`config` - value from settings
`forum_keepers` - count of keepers, forum api (exclude self)
`calc_keepers` - the minimum value of the two above
`seeders` - count of seeders, forum api
`calc_peers` - calculated peer count (`seeders` + `leechers` - `keepers`)