### PR TITLE
add simple click-ctrlclick reset-restore logic

### DIFF
--- a/index.php
+++ b/index.php
@@ -193,7 +193,7 @@ try {
                             <button id="apply_filter" type="button" title="Применить параметры фильтра">
                                 <i class="fa fa-check" aria-hidden="true"></i>
                             </button>
-                            <button type="button" id="filter_reset" title="Сбросить параметры фильтра на значения по умолчанию">
+                            <button type="button" id="filter_reset" title="Click - cбросить параметры фильтра на значения по умолчанию. &#10;Ctrl+Click - восстановить последние сброшенные настройки.">
                                 <i class="fa fa-undo" aria-hidden="true"></i>
                             </button>
                         </div>


### PR DESCRIPTION
Click on `reset` button will save current filter preset to Cookies and reset filters to default.
Ctrl+Click on `reset` button will try to restore saved filter preset if it exists.

![image](https://user-images.githubusercontent.com/54838254/212282652-3a092d56-2b8b-4475-b995-bd62d01d0863.png)
