### PR TITLE
Fix unregistered topics search

### DIFF
--- a/php/actions/get_filtered_list_topics.php
+++ b/php/actions/get_filtered_list_topics.php
@@ -168,10 +168,11 @@ try {
                     $topicBlock .= $pattern;
                 }
             }
+            // тип пульки: раздаю, качаю, на паузе, ошибка
             $stateTorrentClient = '';
             if ($topic['done'] == 1) {
                 $stateTorrentClient = 'fa-arrow-up';
-            } elseif ($topic['done'] == null) {
+            } elseif ($topic['done'] === null) {
                 $stateTorrentClient = 'fa-circle';
             } else {
                 $stateTorrentClient = 'fa-arrow-down';
@@ -774,9 +775,10 @@ try {
                 }
             }
             // тип пульки: раздаю, качаю, на паузе, ошибка
+            $stateTorrentClient = '';
             if ($topic_data['done'] == 1) {
                 $stateTorrentClient = 'fa-arrow-up';
-            } elseif ($topic_data['done'] == null) {
+            } elseif ($topic_data['done'] === null) {
                 $stateTorrentClient = 'fa-circle';
             } else {
                 $stateTorrentClient = 'fa-arrow-down';

--- a/php/common/tor_clients.php
+++ b/php/common/tor_clients.php
@@ -181,6 +181,9 @@ if (!empty($untrackedTorrentHashes)) {
             if (empty($topicData)) {
                 continue;
             }
+            if (in_array($topicData['tor_status'], [7])) {
+                continue;
+            }
             $insertedUntrackedTopics[] = [
                 'id' => $topicID,
                 'ss' => $topicData['forum_id'],
@@ -234,7 +237,6 @@ $topicsUnregistered = Db::query_database(
         Topics.hs IS NULL
         AND TopicsUntracked.hs IS NULL
         AND Torrents.topic_id IS NOT ""
-        AND Torrents.done = 1
     ORDER BY Torrents.name',
     [],
     true,


### PR DESCRIPTION
fix #203 
1. If forum api return status=7, exclude it from valid topics.
`get_tor_topic_data?by=hash&val=728A236C40101F1371C3A9B3CED1289D032DE1FB`
```
    "6294505": {
      "info_hash": "728A236C40101F1371C3A9B3CED1289D032DE1FB",
      "forum_id": 1726,
      "poster_id": 28380987,
      "size": 369855200,
      "reg_time": 1670791290,
      "tor_status": 7,
      "seeders": 10,
      "topic_title": "(Hard Rock) [CD] Skid Row - The Gang's All Here - 2022, FLAC (image+.cue), lossless",
      "seeder_last_seen": 1673835661,
      "dl_count": 356
    }
```


2. Include undone Torrents in unregistered search.
If torrent has not yet been fully downloaded, but its status has changed on the forum - we will find out about it.
4. Fix arrow type for main page (1=upload, 0=download, null=else).