### PR TITLE
Docker. Add control.php, fix permisions

### DIFF
--- a/docker/rootfs/etc/crontabs/root
+++ b/docker/rootfs/etc/crontabs/root
@@ -1,3 +1,4 @@
 15 * * * * sleep $(shuf -i 1-360 -n 1)  && php81 /var/www/webtlo/cron/update.php
+25 * * * * sleep $(shuf -i 1-360 -n 1)  && php81 /var/www/webtlo/cron/control.php
 0 5 * * *  sleep $(shuf -i 1-1200 -n 1) && php81 /var/www/webtlo/cron/keepers.php
 0 6 * * *  sleep $(shuf -i 1-1200 -n 1) && php81 /var/www/webtlo/cron/reports.php

--- a/docker/rootfs/etc/s6-overlay/s6-rc.d/cron/run
+++ b/docker/rootfs/etc/s6-overlay/s6-rc.d/cron/run
@@ -1,12 +1,7 @@
 #!/command/with-contenv bash
 if [ "${WEBTLO_CRON:=false}" = "true" ]; then
-  user="${WEBTLO_UID:=nobody}"
-  group="${WEBTLO_GID:=nobody}"
-  account="$user:$group"
-  uid=$(s6-envuidgid -nB $account importas UID UID s6-echo '$UID')
-  gid=$(s6-envuidgid -nB $account importas GID GID s6-echo '$GID')
-  s6-echo "Enabled cron with user $account"
-  exec s6-setuidgid "$uid:$gid" crond -f
+  s6-echo "Enabled cron jobs"
+  exec crond -f
 else
   s6-echo "Running with disabled cron"
   exec sleep infinity


### PR DESCRIPTION
Close #201 

Исправил запуск cron внутри контейнера, теперь запустк от `root` пользователя. Это исправляет проблему, что крон не запускался вообще, но может принести новые проблемы с правами.
Локально, создаваемые запущенными задачами лог-файлы читаются ТЛО нормально.

Добавил control.php в задачи, т.к. его выполнение можно отключить в настройках ТЛО.