### PR TITLE
Refactoring actions, Topics table

### DIFF
--- a/php/classes/db.php
+++ b/php/classes/db.php
@@ -9,7 +9,7 @@ class Db
     private static string $databaseFilename = 'webtlo.db';
 
     /** Актуальная версия БД */
-    private const PRAGMA_VERSION = 9;
+    private const PRAGMA_VERSION = 10;
 
     public static function query_database($sql, $param = [], $fetch = false, $pdo = PDO::FETCH_ASSOC)
     {
@@ -219,7 +219,9 @@ class Db
             '    rg INT,',                      // reg_time
             '    qt INT,',                      // sum_updates
             '    ds INT,',                      // days_update
-            '    pt INT DEFAULT 1',             // keeping_priority
+            '    pt INT DEFAULT 1,',            // keeping_priority
+            '    ps INT DEFAULT 0,',            // poster_id
+            '    ls INT DEFAULT 0',             // seeder_last_seen
             ');'
         ];
         $statements[] = [
@@ -237,11 +239,14 @@ class Db
             '        rg = CASE WHEN NEW.rg IS NULL THEN rg ELSE NEW.rg END,',
             '        qt = CASE WHEN NEW.qt IS NULL THEN qt ELSE NEW.qt END,',
             '        ds = CASE WHEN NEW.ds IS NULL THEN ds ELSE NEW.ds END,',
-            '        pt = CASE WHEN NEW.pt IS NULL THEN pt ELSE NEW.pt END',
+            '        pt = CASE WHEN NEW.pt IS NULL THEN pt ELSE NEW.pt END,',
+            '        ps = CASE WHEN NEW.ps IS NULL THEN ps ELSE NEW.ps END,',
+            '        ls = CASE WHEN NEW.ls IS NULL THEN ls ELSE NEW.ls END',
             '    WHERE id = NEW.id;',
             '    SELECT RAISE(IGNORE);',
             'END;'
         ];
+        $statements[] = 'CREATE INDEX IF NOT EXISTS IX_Topics_ss_hs ON Topics (ss, hs);';
         $statements[] = [
             'CREATE TRIGGER IF NOT EXISTS topics_delete',
             'AFTER DELETE ON Topics FOR EACH ROW',

--- a/php/common.php
+++ b/php/common.php
@@ -5,6 +5,7 @@ include_once dirname(__FILE__) . '/classes/log.php';
 include_once dirname(__FILE__) . '/classes/db.php';
 include_once dirname(__FILE__) . '/classes/proxy.php';
 include_once dirname(__FILE__) . '/classes/settings.php';
+include_once dirname(__FILE__) . '/classes/Timers.php';
 include_once dirname(__FILE__) . '/migration/Backup.php';
 
 // версия Web-TLO

--- a/php/common/forum_tree.php
+++ b/php/common/forum_tree.php
@@ -3,6 +3,16 @@
 include_once dirname(__FILE__) . '/../common.php';
 include_once dirname(__FILE__) . '/../classes/api.php';
 
+Timers::start('forum_tree');
+/** Ид подраздела обновления дерева подразделов  */
+const FORUM_TREE_UPDATE = 8888;
+
+// Проверяем время последнего обновления.
+if (!check_update_available(FORUM_TREE_UPDATE)) {
+    Log::append('Обновление списка подразделов не требуется.');
+    return;
+}
+
 // получение настроек
 if (!isset($cfg)) {
     $cfg = get_settings();
@@ -15,88 +25,77 @@ if (!isset($api)) {
     $api->setUserConnectionOptions($cfg['curl_setopt']['api']);
 }
 
-// обновление дерева подразделов
-$forum_tree_update = Db::query_database(
-    "SELECT strftime('%s', 'now') - ud FROM UpdateTime WHERE id = ?",
-    [8888],
-    true,
-    PDO::FETCH_COLUMN
-);
+// получение дерева подразделов
+$forumTree = $api->getCategoryForumTree();
 
-if (
-    empty($forum_tree_update)
-    || $forum_tree_update[0] > 3600
-) {
-    // получение дерева подразделов
-    $forum_tree = $api->getCategoryForumTree();
+if (empty($forumTree['result'])) {
+    throw new Exception("Error: Не удалось получить дерево подразделов");
+}
 
-    if (empty($forum_tree['result'])) {
-        throw new Exception("Error: Не удалось получить дерево подразделов");
-    }
+$treeUpdateTime = $forumTree['update_time'];
 
-    $forum_tree_update_current = $forum_tree['update_time'];
-
-    foreach ($forum_tree['result']['c'] as $cat_id => $cat_title) {
-        foreach ($forum_tree['result']['tree'][$cat_id] as $forum_id => $subforum) {
-            // разделы
-            $forum_title = $cat_title . ' » ' . $forum_tree['result']['f'][$forum_id];
-            $forums[$forum_id] = [
-                'na' => $forum_title,
+foreach ($forumTree['result']['c'] as $catId => $catTitle) {
+    foreach ($forumTree['result']['tree'][$catId] as $forum_id => $subForum) {
+        // разделы
+        $forumTitle = $catTitle . ' » ' . $forumTree['result']['f'][$forum_id];
+        $forums[$forum_id] = [
+            'na' => $forumTitle,
+            'qt' => 0,
+            'si' => 0,
+        ];
+        // подразделы
+        foreach ($subForum as $subForumId) {
+            $subForumTitle = $catTitle . ' » ' . $forumTree['result']['f'][$forum_id] . ' » ' . $forumTree['result']['f'][$subForumId];
+            $forums[$subForumId] = [
+                'na' => $subForumTitle,
                 'qt' => 0,
                 'si' => 0,
             ];
-            // подразделы
-            foreach ($subforum as $subforum_id) {
-                $subforum_title = $cat_title . ' » ' . $forum_tree['result']['f'][$forum_id] . ' » ' . $forum_tree['result']['f'][$subforum_id];
-                $forums[$subforum_id] = [
-                    'na' => $subforum_title,
-                    'qt' => 0,
-                    'si' => 0,
-                ];
-            }
+            unset($subForumId, $subForumTitle);
         }
+        unset($forum_id, $forumTitle, $subForum);
     }
-    unset($forum_tree);
+    unset($catId, $catTitle);
+}
+unset($forumTree);
 
-    // получение количества и веса раздач по разделам
-    $forum_size = $api->getCategoryForumVolume();
+// получение количества и веса раздач по разделам
+$forum_size = $api->getCategoryForumVolume();
 
-    if (empty($forum_size['result'])) {
-        throw new Exception("Error: Не удалось получить количество и вес раздач по разделам");
+if (empty($forum_size['result'])) {
+    throw new Exception("Error: Не удалось получить количество и вес раздач по разделам");
+}
+
+foreach ($forum_size['result'] as $forum_id => $values) {
+    if (empty($values)) {
+        continue;
     }
-
-    $forum_size_update_current = $forum_size['update_time'];
-
-    foreach ($forum_size['result'] as $forum_id => $values) {
-        if (empty($values)) {
-            continue;
-        }
-        if (isset($forums[$forum_id])) {
-            $forums[$forum_id] = array_merge(
-                $forums[$forum_id],
-                array_combine(
-                    ['qt', 'si'],
-                    $values
-                )
-            );
-        }
+    if (isset($forums[$forum_id])) {
+        $forums[$forum_id] = array_merge(
+            $forums[$forum_id],
+            array_combine(
+                ['qt', 'si'],
+                $values
+            )
+        );
     }
+}
 
+if (isset($forums) && count($forums)) {
     // создаём временную таблицу
     Db::query_database(
         'CREATE TEMP TABLE ForumsNew AS
-        SELECT id,na,qt,si FROM Forums WHERE 0 = 1'
+    SELECT id,na,qt,si FROM Forums WHERE 0 = 1'
     );
 
     // отправляем в базу данных
-    $forums = array_chunk($forums, 500, true);
+    $forumsChunks = array_chunk($forums, 500, true);
 
-    foreach ($forums as $forums) {
-        $select = Db::combine_set($forums);
+    foreach ($forumsChunks as $forumsParts) {
+        $select = Db::combine_set($forumsParts);
         Db::query_database("INSERT INTO temp.ForumsNew (id,na,qt,si) $select");
-        unset($select);
+        unset($forumsParts, $select);
     }
-    unset($forums);
 
     Log::append("Обновление дерева подразделов...");
 
@@ -108,12 +107,14 @@ if (
         WHERE temp.ForumsNew.id IS NULL
     )');
 
-    // время обновления дерева подразделов
-    Db::query_database(
-        "INSERT INTO UpdateTime (id,ud) SELECT 8888,?",
-        [$forum_tree_update_current]
-    );
 
-    unset($forum_tree_update_current);
-    unset($forum_tree_update);
+    // Записываем время обновления.
+    set_last_update_time(FORUM_TREE_UPDATE, $treeUpdateTime);
+
+    Log::append(sprintf(
+        'Обновление дерева подразделов завершено за %s, обработано подразделов: %d шт',
+        Timers::getExecTime('forum_tree'),
+        count($forums)
+    ));
+    unset($forums, $forumsChunks, $treeUpdateTime);
 }

--- a/php/common/high_priority_topics.php
+++ b/php/common/high_priority_topics.php
@@ -3,10 +3,37 @@
 include_once dirname(__FILE__) . '/../common.php';
 include_once dirname(__FILE__) . '/../classes/api.php';
 
+Timers::start('hp_topics');
+/** Ид подраздела обновления высокоприоритетных раздач */
+const HIGH_PRIORITY_UPDATE = 9999;
+
+// получаем дату предыдущего обновления
+$updateTime = get_last_update_time(HIGH_PRIORITY_UPDATE);
+// если не прошёл час
+if (time() - $updateTime < 3600) {
+    Log::append("Notice: Не требуется обновление списка высокоприоритетных раздач");
+    return;
+}
+
 // получение настроек
 if (!isset($cfg)) {
     $cfg = get_settings();
 }
+
+// подключаемся к api
+if (!isset($api)) {
+    $api = new Api($cfg['api_address'], $cfg['api_key']);
+    // применяем таймауты
+    $api->setUserConnectionOptions($cfg['curl_setopt']['api']);
+}
+
+// получаем данные о раздачах
+$topicsHighPriorityData = $api->getTopicsHighPriority();
+if (empty($topicsHighPriorityData['result'])) {
+    Log::append("Error: Не получены данные о высокоприоритетных раздачах");
+    return;
+}
+
 // создаём временные таблицы
 Db::query_database(
     "CREATE TEMP TABLE HighTopicsUpdate AS
@@ -16,226 +43,199 @@ Db::query_database(
     "CREATE TEMP TABLE HighTopicsRenew AS
     SELECT id,ss,na,hs,se,si,st,rg,qt,ds,pt FROM Topics WHERE 0 = 1"
 );
-// подключаемся к api
-if (!isset($api)) {
-    $api = new Api($cfg['api_address'], $cfg['api_key']);
-    // применяем таймауты
-    $api->setUserConnectionOptions($cfg['curl_setopt']['api']);
-}
+
 // все открытые раздачи
-$torrentStatus = [0, 2, 3, 8, 10];
+$allowedTorrentStatuses = [0, 2, 3, 8, 10];
 // время текущего и предыдущего обновления
-$currentUpdateTime = new DateTime();
+$currentUpdateTime  = new DateTime();
 $previousUpdateTime = new DateTime();
-// получаем дату предыдущего обновления
-$updateTime = Db::query_database(
-    "SELECT ud FROM UpdateTime WHERE id = ?",
-    [9999],
-    true,
-    PDO::FETCH_COLUMN
-);
-// при первом обновлении
-if (empty($updateTime[0])) {
-    $updateTime[0] = 0;
-}
-// разница между обновлениями
-$timeDiff = time() - $updateTime[0];
-// если не прошёл час
-if ($timeDiff < 3600) {
-    Log::append("Notice: Не требуется обновление списка высокоприоритетных раздач");
-} else {
-    // получаем данные о раздачах
-    $topicsHighPriorityData = $api->getTopicsHighPriority();
-    if (empty($topicsHighPriorityData['result'])) {
-        Log::append("Error: Не получены данные о высокоприоритетных раздачах");
-    } else {
-        // время последнего обновления данных на api
-        $topicsHighPriorityUpdateTime = $topicsHighPriorityData['update_time'];
-        // количество раздач
-        $topicsHighPriorityTotalCount = 0;
-        // текущее обновление в DateTime
-        $currentUpdateTime->setTimestamp($topicsHighPriorityData['update_time']);
-        // предыдущее обновление в DateTime
-        $previousUpdateTime->setTimestamp($updateTime[0])->setTime(0, 0, 0);
-        // разница в днях между обновлениями сведений
-        $daysDiffAdjusted = $currentUpdateTime->diff($previousUpdateTime)->format('%d');
-        // разбиваем result по 500 раздач
-        $topicsHighPriorityResult = array_chunk($topicsHighPriorityData['result'], 500, true);
-        unset($topicsHighPriorityData);
-        // проходим по всем раздачам
-        foreach ($topicsHighPriorityResult as $topicsHighPriorityResult) {
-            // получаем данные о раздачах за предыдущее обновление
-            $topicsIDs = array_keys($topicsHighPriorityResult);
-            $in = str_repeat('?,', count($topicsIDs) - 1) . '?';
-            $previousTopicsData = Db::query_database(
-                "SELECT id,se,rg,qt,ds,length(na) as lgth FROM Topics WHERE id IN ($in)",
-                $topicsIDs,
-                true,
-                PDO::FETCH_ASSOC | PDO::FETCH_UNIQUE
-            );
-            unset($topicsIDs);
-            // разбираем раздачи
-            // topic_id => array( tor_status, seeders, reg_time, tor_size_bytes, forum_id )
-            foreach ($topicsHighPriorityResult as $topicID => $topicData) {
-                if (empty($topicData)) {
-                    continue;
-                }
-                if (count($topicData) < 5) {
-                    throw new Exception("Error: Недостаточно элементов в ответе");
-                }
-                if (!in_array($topicData[0], $torrentStatus)) {
-                    continue;
-                }
-                $numberDaysUpdate = 0;
-                $sumUpdates = 1;
-                $sumSeeders = $topicData[1];
-                // запоминаем имеющиеся данные о раздаче в локальной базе
-                if (isset($previousTopicsData[$topicID])) {
-                    $previousTopicData = $previousTopicsData[$topicID];
-                }
-                // удалить перерегистрированную раздачу
-                // в том числе, чтобы очистить значения сидов для старой раздачи
-                if (
-                    isset($previousTopicData['rg'])
-                    && $previousTopicData['rg'] != $topicData[2]
-                ) {
-                    $topicsDelete[] = $topicID;
-                    $isTopicDataDelete = true;
-                } else {
-                    $isTopicDataDelete = false;
-                }
-                // получить для раздачи info_hash и topic_title
-                if (
-                    empty($previousTopicData)
-                    || $previousTopicData['lgth'] == 0
-                    || $isTopicDataDelete
-                ) {
-                    $insertTopicsRenew[$topicID] = [
-                        'id' => $topicID,
-                        'ss' => $topicData[4],
-                        'na' => '',
-                        'hs' => '',
-                        'se' => $sumSeeders,
-                        'si' => $topicData[3],
-                        'st' => $topicData[0],
-                        'rg' => $topicData[2],
-                        'qt' => $sumUpdates,
-                        'ds' => $numberDaysUpdate,
-                        'pt' => 2,
-                    ];
-                    unset($previousTopicData);
-                    continue;
-                }
-                // алгоритм нахождения среднего значения сидов
-                if ($cfg['avg_seeders']) {
-                    $numberDaysUpdate = $previousTopicData['ds'];
-                    // по прошествии дня
-                    if ($daysDiffAdjusted > 0) {
-                        $numberDaysUpdate++;
-                    } else {
-                        $sumUpdates += $previousTopicData['qt'];
-                        $sumSeeders += $previousTopicData['se'];
-                    }
-                }
-                unset($previousTopicData);
-                $insertTopicsUpdate[$topicID] = [
-                    'id' => $topicID,
-                    'ss' => $topicData[4],
-                    'se' => $sumSeeders,
-                    'st' => $topicData[0],
-                    'qt' => $sumUpdates,
-                    'ds' => $numberDaysUpdate,
-                    'pt' => 2,
-                ];
-            }
-            unset($previousTopicsData);
-            // вставка данных в базу о новых раздачах
-            if (isset($insertTopicsRenew)) {
-                $topicsIDsRenew = array_keys($insertTopicsRenew);
-                $in = str_repeat('?,', count($topicsIDsRenew) - 1) . '?';
-                $topicsHighPriorityData = $api->getTorrentTopicData($topicsIDsRenew);
-                unset($topicsIDsRenew);
-                if (empty($topicsHighPriorityData)) {
-                    throw new Exception("Error: Не получены дополнительные данные о раздачах");
-                }
-                foreach ($topicsHighPriorityData as $topicID => $topicData) {
-                    if (empty($topicData)) {
-                        continue;
-                    }
-                    if (isset($insertTopicsRenew[$topicID])) {
-                        $insertTopicsRenew[$topicID]['hs'] = $topicData['info_hash'];
-                        $insertTopicsRenew[$topicID]['na'] = $topicData['topic_title'];
-                    }
-                }
-                unset($topicsHighPriorityData);
-                $select = Db::combine_set($insertTopicsRenew);
-                unset($insertTopicsRenew);
-                Db::query_database("INSERT INTO temp.HighTopicsRenew $select");
-                unset($select);
-            }
-            unset($insertTopicsRenew);
-            // обновление данных в базе о существующих раздачах
-            if (isset($insertTopicsUpdate)) {
-                $select = Db::combine_set($insertTopicsUpdate);
-                unset($insertTopicsUpdate);
-                Db::query_database("INSERT INTO temp.HighTopicsUpdate $select");
-                unset($select);
-            }
-            unset($insertTopicsUpdate);
+
+// время последнего обновления данных на api
+$topicsHighPriorityUpdateTime = $topicsHighPriorityData['update_time'];
+// количество раздач
+$topicsHighPriorityTotalCount = 0;
+// текущее обновление в DateTime
+$currentUpdateTime->setTimestamp($topicsHighPriorityData['update_time']);
+// предыдущее обновление в DateTime
+$previousUpdateTime->setTimestamp($updateTime)->setTime(0, 0);
+// разница в днях между обновлениями сведений
+$daysDiffAdjusted = $currentUpdateTime->diff($previousUpdateTime)->format('%d');
+// разбиваем result по 500 раздач
+$topicsHighPriorityResultChunk = array_chunk($topicsHighPriorityData['result'], 500, true);
+
+$topicsKeys = $topicsHighPriorityData['format']['topic_id'];
+unset($topicsHighPriorityData);
+
+// проходим по всем раздачам
+foreach ($topicsHighPriorityResultChunk as $topicsHighPriorityResult) {
+    // получаем данные о раздачах за предыдущее обновление
+    $topicsIDs = array_keys($topicsHighPriorityResult);
+    $in = str_repeat('?,', count($topicsIDs) - 1) . '?';
+
+    $previousTopicsData = Db::query_database(
+        "SELECT id,se,rg,qt,ds,length(na) as lgth FROM Topics WHERE id IN ($in)",
+        $topicsIDs,
+        true,
+        PDO::FETCH_ASSOC | PDO::FETCH_UNIQUE
+    );
+    unset($topicsIDs);
+    // разбираем раздачи
+    // topic_id => array( tor_status, seeders, reg_time, tor_size_bytes, forum_id )
+    foreach ($topicsHighPriorityResult as $topicID => $topicRaw) {
+        if (empty($topicRaw)) {
+            continue;
         }
-        unset($topicsHighPriorityResult);
-        // удаляем перерегистрированные раздачи
-        // чтобы очистить значения сидов для старой раздачи
-        if (isset($topicsDelete)) {
-            $topicsDelete = array_chunk($topicsDelete, 500);
-            foreach ($topicsDelete as $topicsDelete) {
-                $in = str_repeat('?,', count($topicsDelete) - 1) . '?';
-                Db::query_database(
-                    "DELETE FROM Topics WHERE id IN ($in)",
-                    $topicsDelete
-                );
-            }
+        if (count($topicRaw) < 5) {
+            throw new Exception("Error: Недостаточно элементов в ответе");
         }
-        $countTopicsUpdate = Db::query_database(
-            "SELECT COUNT() FROM temp.HighTopicsUpdate",
-            [],
-            true,
-            PDO::FETCH_COLUMN
-        );
-        $countTopicsRenew = Db::query_database(
-            "SELECT COUNT() FROM temp.HighTopicsRenew",
-            [],
-            true,
-            PDO::FETCH_COLUMN
-        );
+        $topicData = array_combine($topicsKeys, $topicRaw);
+        if (!in_array($topicData['tor_status'], $allowedTorrentStatuses)) {
+            continue;
+        }
+
+        $daysUpdate = 0;
+        $sumUpdates = 1;
+        $sumSeeders = $topicData['seeders'];
+        // запоминаем имеющиеся данные о раздаче в локальной базе
+        if (isset($previousTopicsData[$topicID])) {
+            $previousTopicData = $previousTopicsData[$topicID];
+        }
+        // удалить перерегистрированную раздачу
+        // в том числе, чтобы очистить значения сидов для старой раздачи
         if (
-            $countTopicsUpdate[0] > 0
-            || $countTopicsRenew[0] > 0
+            isset($previousTopicData['rg'])
+            && $previousTopicData['rg'] != $topicData['reg_time']
         ) {
-            // переносим данные в основную таблицу
-            Db::query_database(
-                "INSERT INTO Topics (id,ss,se,st,qt,ds,pt)
-                    SELECT * FROM temp.HighTopicsUpdate"
-            );
-            Db::query_database(
-                "INSERT INTO Topics (id,ss,na,hs,se,si,st,rg,qt,ds,pt)
-                    SELECT * FROM temp.HighTopicsRenew"
-            );
-            Db::query_database(
-                "DELETE FROM Topics WHERE id IN (
-                    SELECT Topics.id FROM Topics
-                    LEFT JOIN temp.HighTopicsUpdate ON Topics.id = temp.HighTopicsUpdate.id
-                    LEFT JOIN temp.HighTopicsRenew ON Topics.id = temp.HighTopicsRenew.id
-                    WHERE temp.HighTopicsUpdate.id IS NULL AND temp.HighTopicsRenew.id IS NULL AND Topics.pt = 2
-                )"
-            );
-            // время окончания обновления
-            Db::query_database(
-                "INSERT INTO UpdateTime (id,ud) SELECT 9999,?",
-                [$topicsHighPriorityUpdateTime]
-            );
-            $countTopicsTotalUpdate = $countTopicsUpdate[0] + $countTopicsRenew[0];
-            Log::append("Обработано высокоприоритетных раздач: " . $countTopicsTotalUpdate . " шт.");
+            $topicsDelete[]    = $topicID;
+            $isTopicDataDelete = true;
+        } else {
+            $isTopicDataDelete = false;
         }
+        // получить для раздачи info_hash и topic_title
+        if (
+            empty($previousTopicData)
+            || $isTopicDataDelete
+            || $previousTopicData['lgth'] == 0
+        ) {
+            $insertTopicsRenew[$topicID] = [
+                'id' => $topicID,
+                'ss' => $topicData['forum_id'],
+                'na' => '',
+                'hs' => '',
+                'se' => $sumSeeders,
+                'si' => $topicData['tor_size_bytes'],
+                'st' => $topicData['tor_status'],
+                'rg' => $topicData['reg_time'],
+                'qt' => $sumUpdates,
+                'ds' => $daysUpdate,
+                'pt' => 2,
+            ];
+            unset($previousTopicData);
+            continue;
+        }
+        // алгоритм нахождения среднего значения сидов
+        if ($cfg['avg_seeders']) {
+            $daysUpdate = $previousTopicData['ds'];
+            // по прошествии дня
+            if ($daysDiffAdjusted > 0) {
+                $daysUpdate++;
+            } else {
+                $sumUpdates += $previousTopicData['qt'];
+                $sumSeeders += $previousTopicData['se'];
+            }
+        }
+        unset($previousTopicData);
+
+        $insertTopicsUpdate[$topicID] = [
+            'id' => $topicID,
+            'ss' => $topicData['forum_id'],
+            'se' => $sumSeeders,
+            'st' => $topicData['tor_status'],
+            'qt' => $sumUpdates,
+            'ds' => $daysUpdate,
+            'pt' => 2,
+        ];
     }
+    unset($previousTopicsData);
+
+    // вставка данных в базу о новых раздачах
+    if (isset($insertTopicsRenew)) {
+        $topicsIDsRenew = array_keys($insertTopicsRenew);
+        $in = str_repeat('?,', count($topicsIDsRenew) - 1) . '?';
+
+        $topicsHighPriorityData = $api->getTorrentTopicData($topicsIDsRenew);
+        unset($topicsIDsRenew);
+        if (empty($topicsHighPriorityData)) {
+            throw new Exception("Error: Не получены дополнительные данные о раздачах");
+        }
+        foreach ($topicsHighPriorityData as $topicID => $topicData) {
+            if (empty($topicData)) {
+                continue;
+            }
+            if (isset($insertTopicsRenew[$topicID])) {
+                $insertTopicsRenew[$topicID]['hs'] = $topicData['info_hash'];
+                $insertTopicsRenew[$topicID]['na'] = $topicData['topic_title'];
+            }
+        }
+        unset($topicsHighPriorityData);
+        $select = Db::combine_set($insertTopicsRenew);
+        unset($insertTopicsRenew);
+        Db::query_database("INSERT INTO temp.HighTopicsRenew $select");
+        unset($insertTopicsRenew, $select);
+    }
+
+    // обновление данных в базе о существующих раздачах
+    if (isset($insertTopicsUpdate)) {
+        $select = Db::combine_set($insertTopicsUpdate);
+        unset($insertTopicsUpdate);
+        Db::query_database("INSERT INTO temp.HighTopicsUpdate $select");
+        unset($select);
+    }
+    unset($insertTopicsUpdate);
+}
+unset($topicsHighPriorityResult);
+
+// удаляем перерегистрированные раздачи
+// чтобы очистить значения сидов для старой раздачи
+if (isset($topicsDelete)) {
+    $topicsDeleteChunk = array_chunk($topicsDelete, 500);
+    foreach ($topicsDeleteChunk as $topicsDeletePart) {
+        $in = str_repeat('?,', count($topicsDeletePart) - 1) . '?';
+        Db::query_database(
+            "DELETE FROM Topics WHERE id IN ($in)",
+            $topicsDeletePart
+        );
+        unset($topicsDeletePart, $im);
+    }
+    unset($topicsDelete, $topicsDeleteChunk);
+}
+
+$countTopicsUpdate = Db::query_count('SELECT COUNT() FROM temp.HighTopicsUpdate');
+$countTopicsRenew  = Db::query_count('SELECT COUNT() FROM temp.HighTopicsRenew');
+if ($countTopicsUpdate > 0 || $countTopicsRenew > 0) {
+    // переносим данные в основную таблицу
+    Db::query_database(
+        "INSERT INTO Topics (id,ss,se,st,qt,ds,pt)
+            SELECT * FROM temp.HighTopicsUpdate"
+    );
+    Db::query_database(
+        "INSERT INTO Topics (id,ss,na,hs,se,si,st,rg,qt,ds,pt)
+            SELECT * FROM temp.HighTopicsRenew"
+    );
+    Db::query_database(
+        "DELETE FROM Topics WHERE id IN (
+            SELECT Topics.id FROM Topics
+            LEFT JOIN temp.HighTopicsUpdate ON Topics.id = temp.HighTopicsUpdate.id
+            LEFT JOIN temp.HighTopicsRenew ON Topics.id = temp.HighTopicsRenew.id
+            WHERE temp.HighTopicsUpdate.id IS NULL AND temp.HighTopicsRenew.id IS NULL AND Topics.pt = 2
+        )"
+    );
+    // Записываем время обновления.
+    set_last_update_time(HIGH_PRIORITY_UPDATE, $topicsHighPriorityUpdateTime);
+
+    Log::append(sprintf(
+        'Обновление высокоприоритетных раздач завершено за %s, обработано раздач: %d шт',
+        Timers::getExecTime('hp_topics'),
+        $countTopicsUpdate + $countTopicsRenew
+    ));
 }

--- a/php/migration/DatabaseMigration.php
+++ b/php/migration/DatabaseMigration.php
@@ -718,4 +718,38 @@ class DatabaseMigration
         ];
         $this->statements[] = 'PRAGMA user_version = 9';
     }
+
+    // user_version = 10
+    private function setPragmaVersion_10(): void
+    {
+        // Новые поля в списке раздач.
+        $this->statements[] = 'ALTER TABLE Topics ADD COLUMN ps INT DEFAULT 0'; // poster_id
+        $this->statements[] = 'ALTER TABLE Topics ADD COLUMN ls INT DEFAULT 0'; // seeder_last_seen
+        $this->statements[] = 'DROP TRIGGER IF EXISTS topic_exists';
+        $this->statements[] = [
+            'CREATE TRIGGER IF NOT EXISTS topic_exists',
+            'BEFORE INSERT ON Topics',
+            'WHEN EXISTS (SELECT id FROM Topics WHERE id = NEW.id)',
+            'BEGIN',
+            '    UPDATE Topics SET',
+            '        ss = CASE WHEN NEW.ss IS NULL THEN ss ELSE NEW.ss END,',
+            '        na = CASE WHEN NEW.na IS NULL THEN na ELSE NEW.na END,',
+            '        hs = CASE WHEN NEW.hs IS NULL THEN hs ELSE NEW.hs END,',
+            '        se = CASE WHEN NEW.se IS NULL THEN se ELSE NEW.se END,',
+            '        si = CASE WHEN NEW.si IS NULL THEN si ELSE NEW.si END,',
+            '        st = CASE WHEN NEW.st IS NULL THEN st ELSE NEW.st END,',
+            '        rg = CASE WHEN NEW.rg IS NULL THEN rg ELSE NEW.rg END,',
+            '        qt = CASE WHEN NEW.qt IS NULL THEN qt ELSE NEW.qt END,',
+            '        ds = CASE WHEN NEW.ds IS NULL THEN ds ELSE NEW.ds END,',
+            '        pt = CASE WHEN NEW.pt IS NULL THEN pt ELSE NEW.pt END,',
+            '        ps = CASE WHEN NEW.ps IS NULL THEN ps ELSE NEW.ps END,',
+            '        ls = CASE WHEN NEW.ls IS NULL THEN ls ELSE NEW.ls END',
+            '    WHERE id = NEW.id;',
+            '    SELECT RAISE(IGNORE);',
+            'END;'
+        ];
+        $this->statements[] = 'CREATE INDEX IF NOT EXISTS IX_Topics_ss_hs ON Topics (ss, hs);';
+
+        $this->statements[] = 'PRAGMA user_version = 10';
+    }
 }


### PR DESCRIPTION
Рефакторинг алгоритмов:
- получения дерева подразделов `forum_tree`
- получения списка высокоприоритетных раздач `high_priority_topics`
- обновления списка раздач хранимых подразделов `update`

Обновление таблицы `Topics`:
- добавлены поля `poster_id` - ид автора раздачи, `seeder_last_seen` - последняя активность сидов
- исправление триггера обновления таблицы при вставке дублей
- добавлен индекс по ид подраздела для статистики
- поднята версия БД до 10
- подкорректированы скрипты миграции и первичного запуска для 10й версии

Новые поля в БД будут нужны для: #74, #90, #206

Исправил скрипт миграции до db_version_8. Теперь имеющиеся записи о хранимых раздачах в таблице `Clients` будут копироваться в новую таблицу `Torrents` при пересоздании таблиц, #157.