### PR TITLE
Filter. Put new topics query on hold when some tasks are running

### DIFF
--- a/scripts/jquery.actions.js
+++ b/scripts/jquery.actions.js
@@ -6,16 +6,19 @@ $(document).ready(function () {
 			type: "POST",
 			url: "php/actions/update_info.php",
 			beforeSend: function () {
+				filter_hold = true;
 				block_actions();
 				$("#process").text("Обновление сведений о раздачах...");
 			},
 			success: function (response) {
+				filter_hold = false;
 				response = $.parseJSON(response);
 				$("#log").append(response.log);
 				showResultTopics(response.result);
 				getFilteredTopics();
 			},
 			complete: function () {
+				filter_hold = false;
 				block_actions();
 			},
 		});

--- a/scripts/jquery.topics.js
+++ b/scripts/jquery.topics.js
@@ -437,14 +437,19 @@ $(document).ready(function () {
 
 
 // задержка при выборе свойств фильтра
-var filter_delay = makeDelay(600);
+let filter_delay = makeDelay(600);
 
 // подавление срабатывания фильтрации раздач
-var filter_hold = false;
+let filter_hold = false;
 
 // получение отфильтрованных раздач из базы
 function getFilteredTopics() {
-	var forum_id = $("#main-subsections").val();
+	// Ставим в "очередь" поиск раздач при выполнении тяжелых запросов.
+	if (filter_hold) {
+		return filter_delay(getFilteredTopics);
+	}
+
+	let forum_id = $("#main-subsections").val();
 	$("#excluded_topics_size").parent().hide();
 	$("#loading, #process").hide();
 
@@ -515,9 +520,11 @@ function getFilteredTopics() {
 			filter: $filter,
 		},
 		beforeSend: function () {
+			filter_hold = true;
 			block_actions();
 		},
 		complete: function () {
+			filter_hold = false;
 			block_actions();
 		},
 		success: function (response) {


### PR DESCRIPTION
Close #242 

Использован существующий признак `filter_hold`. Если он задан, то выполнение поиска раздач будет поставлено в "очередь", до тех пор, пока не выполнится обновление сведений или не завершится выполнение текущего поиска.