### PR TITLE
Атомарное сохранение конфиг-файла.

### DIFF
--- a/php/classes/settings.php
+++ b/php/classes/settings.php
@@ -84,7 +84,8 @@ class TIniFileEx
         if ($r == false) {
             return false;
         }
-        return $wRes;    }
+        return $wRes;
+    }
 
     public static function updateFile()
     {

--- a/php/classes/settings.php
+++ b/php/classes/settings.php
@@ -74,8 +74,17 @@ class TIniFileEx
             }
             $result .= _BR_;
         }
-        return file_put_contents(self::$filename, $result);
-    }
+
+        // Write config file atomically
+        $wRes = file_put_contents(self::$filename .".tmp", $result, LOCK_EX);
+        if ($wRes === false) {
+            return $wRes;
+        }
+        $r = rename(self::$filename . ".tmp", self::$filename);
+        if ($r == false) {
+            return false;
+        }
+        return $wRes;    }
 
     public static function updateFile()
     {


### PR DESCRIPTION
Использование file_put_contents() в редких случаях может вызвать гонку и повреждение конфиг файла.