### PR TITLE
Reports. Add htmlspecialchars for keeper_name

### DIFF
--- a/php/classes/reports.php
+++ b/php/classes/reports.php
@@ -418,9 +418,9 @@ class Reports
 
                     $nickname = $row->find('p.nick > a')->text();
                     $keepers[$index] = [
-                        'post_id' => $link_data->p,
-                        'user_id' => $link_data->u,
-                        'nickname' => $nickname,
+                        'post_id'  => $link_data->p,
+                        'user_id'  => $link_data->u,
+                        'nickname' => htmlspecialchars($nickname),
                     ];
                     unset($link_data);
 


### PR DESCRIPTION
Close #248

Добавлена замена спецсимволов в никах хранителей, чтобы ники типа `nick&nick` заменялись на `nick&amp;nick`, ведь именно в таком виде никнеймы хранителей ТЛО получает от апи трекера.