### PR TITLE
Flood: fixed save path for new torrents

### DIFF
--- a/php/classes/flood.php
+++ b/php/classes/flood.php
@@ -138,7 +138,7 @@ class Flood extends TorrentClient
     {
         $fields = [
             'files' => [base64_encode(file_get_contents($torrentFilePath))],
-            'destination' => '', # $savePath,
+            'destination' => $savePath,
             'start' => true
             ];
         $response = $this->makeRequest('api/torrents/add-files', $fields);


### PR DESCRIPTION
Forgot to remove the prototype-stage override of savepath to empty, so that the default would be used.