### PR TITLE
docker: allow up to 100k input vars

### DIFF
--- a/docker/rootfs/etc/php81/php-fpm.d/www.conf
+++ b/docker/rootfs/etc/php81/php-fpm.d/www.conf
@@ -12,4 +12,5 @@ php_flag[display_errors] = off
 php_admin_flag[log_errors] = on
 php_admin_value[memory_limit] = 2G
 php_admin_value[max_input_time] = 0
+php_admin_value[max_input_vars] = 100000
 php_admin_value[max_execution_time] = 0


### PR DESCRIPTION
Other versions already come with such configuration set, except for OpenServer ones where it's up to the user to change settings.