### PR TITLE
CI. Автоматическая запись версии ПО в version.json из тега/названия ветки

### DIFF
--- a/.github/workflows/build-on-branch.yml
+++ b/.github/workflows/build-on-branch.yml
@@ -12,17 +12,26 @@ jobs:
     name: Check
     uses: ./.github/workflows/sub-check.yml
 
+  metadata:
+    name: Meta
+    uses: ./.github/workflows/sub-metadata.yml
+
   docker:
     name: Build
-    needs: [ validate ]
+    needs: [ validate, metadata ]
     uses: ./.github/workflows/sub-build-docker.yml
     with:
       REGISTRY_IMAGE: ${{ vars.REGISTRY_IMAGE || 'berkut174/webtlo' }}
+      WEBTLO_VERSION: ${{ needs.metadata.outputs.version }}
+      WEBTLO_SHA: ${{ needs.metadata.outputs.sha }}
     secrets:
       DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
       DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
   zip:
     name: Build
-    needs: [ validate ]
+    needs: [ validate, metadata ]
     uses: ./.github/workflows/sub-build-zip.yml
+    with:
+      WEBTLO_VERSION: ${{ needs.metadata.outputs.version }}
+      WEBTLO_SHA: ${{ needs.metadata.outputs.sha }}

--- a/.github/workflows/build-on-tag.yml
+++ b/.github/workflows/build-on-tag.yml
@@ -15,20 +15,29 @@ jobs:
     name: Check
     uses: ./.github/workflows/sub-check.yml
 
+  metadata:
+    name: Meta
+    uses: ./.github/workflows/sub-metadata.yml
+
   docker:
     name: Build
-    needs: [ validate ]
+    needs: [ validate, metadata ]
     uses: ./.github/workflows/sub-build-docker.yml
     with:
       REGISTRY_IMAGE: ${{ vars.REGISTRY_IMAGE || 'berkut174/webtlo' }}
+      WEBTLO_VERSION: ${{ needs.metadata.outputs.version }}
+      WEBTLO_SHA: ${{ needs.metadata.outputs.sha }}
     secrets:
       DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
       DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
   zip:
     name: Build
-    needs: [ validate ]
+    needs: [ validate, metadata ]
     uses: ./.github/workflows/sub-build-zip.yml
+    with:
+      WEBTLO_VERSION: ${{ needs.metadata.outputs.version }}
+      WEBTLO_SHA: ${{ needs.metadata.outputs.sha }}
 
   make-release:
     name: Make release

--- a/.github/workflows/sub-build-docker.yml
+++ b/.github/workflows/sub-build-docker.yml
@@ -6,6 +6,12 @@ on:
       REGISTRY_IMAGE:
         required: true
         type: string
+      WEBTLO_VERSION:
+        type: string
+        default: 'unknown'
+      WEBTLO_SHA:
+        type: string
+        default: 'none'
     secrets:
       DOCKER_HUB_USERNAME:
         required: true
@@ -19,6 +25,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Write version
+        run: |
+          cd src
+          cat version.json \
+            | jq --arg V ${{ inputs.WEBTLO_VERSION }} '.version=$V' \
+            | jq --arg SH ${{ inputs.WEBTLO_SHA }} '.sha=$SH' \
+            > tmp.$$.json
+          mv tmp.$$.json version.json
 
       - name: Docker meta
         id: meta

--- a/.github/workflows/sub-build-zip.yml
+++ b/.github/workflows/sub-build-zip.yml
@@ -2,25 +2,35 @@ name: Sub. Build webtlo zip
 
 on:
   workflow_call:
+    inputs:
+      WEBTLO_VERSION:
+        type: string
+        default: 'unknown'
+      WEBTLO_SHA:
+        type: string
+        default: 'none'
 
 jobs:
   build-zip:
     name: webtlo zip
     runs-on: ubuntu-latest
-    env:
-      WEBTLO_VERSION: ${{ github.ref_name || 'release' }}
     steps:
-      - run: |
-          echo $WEBTLO_VERSION
-          echo ${{ vars.WEBTLO_VERSION }}
-          echo ${{ github.ref_name }}
       - uses: actions/checkout@v4
       - name: Install dependencies
         uses: php-actions/composer@v6
         with:
           working_dir: src
-          args: --ignore-platform-reqs --optimize-autoloader
+          args: --ignore-platform-reqs
           dev: no
+
+      - name: Write version
+        run: |
+          cd src
+          cat version.json \
+            | jq --arg V ${{ inputs.WEBTLO_VERSION }} '.version=$V' \
+            | jq --arg SH ${{ inputs.WEBTLO_SHA }} '.sha=$SH' \
+            > tmp.$$.json
+          mv tmp.$$.json version.json
 
       - run: mkdir -p release
       - name: Build webtlo.zip
@@ -35,7 +45,7 @@ jobs:
 
       - name: Build webtlo-win.zip
         run: |
-          zip_name="webtlo-win-$WEBTLO_VERSION.zip"
+          zip_name="webtlo-win-${{ inputs.WEBTLO_VERSION }}.zip"
           zip_dir=webtlo-win
 
           rm -rf $zip_dir
@@ -73,6 +83,7 @@ jobs:
           retention-days: 7
 
       - name: Cache release
+        if: ${{ github.ref_type == 'tag' }}
         uses: actions/cache@v3
         with:
           path: ./release

--- a/.github/workflows/sub-metadata.yml
+++ b/.github/workflows/sub-metadata.yml
@@ -1,0 +1,39 @@
+name: Sub. Get WebTLO version
+
+on:
+  workflow_call:
+    # Map the workflow outputs to job outputs
+    outputs:
+      version:
+        description: "Version of app"
+        value: ${{ jobs.metadata.outputs.version }}
+      sha:
+        description: "Commit sha-hash"
+        value: ${{ jobs.metadata.outputs.sha }}
+
+jobs:
+  metadata:
+    name: get version
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      sha: ${{ steps.version.outputs.sha }}
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get metadata
+        uses: docker/metadata-action@v5
+        with:
+          tags: type=sha,prefix=
+
+      - name: Get git ref version, sha
+        id: version
+        run: |
+          version=$( cd src && cat version.json | jq -r --arg V -br-${{ github.ref_name }} '.version + $V' )
+          [ ${{ github.ref_type }} == 'tag' ] && version=${{ github.ref_name }}
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "sha=$DOCKER_METADATA_OUTPUT_TAGS" >> "$GITHUB_OUTPUT"
+
+          echo "webtlo-version=$version, sha=$DOCKER_METADATA_OUTPUT_TAGS"

--- a/src/back/WebTLO.php
+++ b/src/back/WebTLO.php
@@ -12,6 +12,7 @@ final class WebTLO
         public readonly string $wiki,
         public readonly string $release,
         public readonly string $releaseApi,
+        public readonly string $sha,
     ) {
     }
 
@@ -36,6 +37,7 @@ final class WebTLO
             $result['wiki'] ?? '#',
             $result['release'] ?? '',
             $result['release_api'] ?? '',
+            $result['sha'] ?? '',
         );
     }
 
@@ -58,8 +60,24 @@ final class WebTLO
         return sprintf('Версия TLO: [b]Web-TLO-[url=%s]%s[/url][/b]', $this->versionUrl(), $this->version);
     }
 
-    public function wikiUrl(): string
+    public function getReleaseLink(): string
     {
-        return $this->wiki;
+        return sprintf('Web-TLO <a href="%s" target="_blank">%s</a>', $this->versionUrl(), $this->version);
+    }
+
+    public function getCommitLink(): string
+    {
+        if (empty($this->sha)) {
+            return '';
+        }
+
+        $url = sprintf('%s/commit/%s', $this->github, $this->sha);
+
+        return sprintf('<a class="version-sha" href="%s" target="_blank">#%s</a>', $url, $this->sha);
+    }
+
+    public function getWikiLink(): string
+    {
+        return sprintf('<a href="%s" target="_blank">Web-TLO wiki</a>', $this->wiki);
     }
 }

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -685,6 +685,11 @@ div.toolbar-buttons > button.ui-button {
     line-height: 1.5;
 }
 
+#manual a.version-sha {
+    font-size: 0.8em;
+    color: #7f7676;
+}
+
 #new_version_available {
     position: absolute;
     right: 25px;

--- a/src/index.php
+++ b/src/index.php
@@ -1127,9 +1127,14 @@ function cfg_checkbox($cfg): Closure
                 </div>
             </div>
             <div id="manual" class="content">
-                <p>Web-TLO <a href="<?= $webtlo->versionUrl() ?>" target="_blank"><?= $webtlo->version ?></a></p>
+                <p>
+                    <?= $webtlo->getReleaseLink() ?>
+                    <?= $webtlo->getCommitLink() ?>
+                </p>
                 <p>Простое веб-приложение для управления торрентами</p>
-                <p><a href="<?= $webtlo->wikiUrl() ?>" target="_blank">Web-TLO wiki</a></p>
+                <p>
+                    <?= $webtlo->getWikiLink() ?>
+                </p>
                 <p>Copyright © 2016-2024 Alexander Shemetov</p>
             </div>
         </div>


### PR DESCRIPTION
- Добавлена запись в version.json текущей версии ПО при пуше ветки/тега. 
- Добавлена запись sha-коммита.
- Добавлено визуальное отображение sha-коммита и ссылки на него.
![image](https://github.com/keepers-team/webtlo/assets/54838254/f2ae883a-2ef9-4333-850b-367a6b9d9f3b)

- Для win-standalone убрано composer dumpautoload, для упрощения обновления с заменой файлов.