### PR TITLE
БД. Обновление таблиц, исправление определения даты отчётов

### DIFF
--- a/src/back/DB.php
+++ b/src/back/DB.php
@@ -14,7 +14,7 @@ use Throwable;
 final class DB
 {
     /** Актуальная версия БД */
-    private const DATABASE_VERSION = 12;
+    private const DATABASE_VERSION = 13;
 
     /** Инициализация таблиц актуальной версии. */
     private const INIT_FILE = '9999-init-database.sql';

--- a/src/back/Enum/UpdateMark.php
+++ b/src/back/Enum/UpdateMark.php
@@ -21,4 +21,17 @@ enum UpdateMark: int
     case FULL_UPDATE   = 9900;
     /** Успешная отправка отчётов. */
     case SEND_REPORT   = 9901;
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::FORUM_TREE    => 'Дерево подразделов',
+            self::SUBSECTIONS   => 'Списки хранимых раздач в подразделах',
+            self::HIGH_PRIORITY => 'Раздачи с высоким приоритетом хранения',
+            self::FORUM_SCAN    => 'Сканирование списков на форуме',
+            self::CLIENTS       => 'Раздачи в торрент-клиентах',
+            self::FULL_UPDATE   => 'Полное обновление всех сведений',
+            self::SEND_REPORT   => 'Успешная отправка отчётов',
+        };
+    }
 }

--- a/src/back/Module/TopicDetails.php
+++ b/src/back/Module/TopicDetails.php
@@ -16,10 +16,10 @@ final class TopicDetails
 {
     private const TOPIC_KEYS = [
         'id', // topic_id
-        'hs', // info_hash
-        'na', // topic_title
-        'ps', // poster_id
-        'ls', // seeder_last_seen
+        'info_hash',
+        'name', // topic_title
+        'poster', // poster_id
+        'seeder_last_seen',
     ];
 
     private ?UpdateDetailsResultObject $result = null;
@@ -103,14 +103,14 @@ final class TopicDetails
     /** Количество раздач без названия. */
     public static function countUnnamed(): int
     {
-        return Db::query_count("SELECT COUNT(1) FROM Topics WHERE na IS NULL OR na = ''");
+        return Db::query_count("SELECT COUNT(1) FROM Topics WHERE name IS NULL OR name = ''");
     }
 
-    /** Количество раздач без названия. */
+    /** Получить N раздач без названия. */
     public static function getUnnamedTopics(int $limit = 5000): array
     {
         return Db::query_database(
-            "select id from Topics WHERE na IS NULL or na = '' LIMIT ?",
+            "SELECT id FROM Topics WHERE name IS NULL OR name = '' LIMIT ?",
             [$limit],
             true,
             PDO::FETCH_COLUMN

--- a/src/back/Module/Topics.php
+++ b/src/back/Module/Topics.php
@@ -22,7 +22,7 @@ final class Topics
         foreach ($hashes as $chunk) {
             $search = KeysObject::create($chunk);
             $topics = Db::query_database(
-                "SELECT hs, id topic_id FROM Topics WHERE hs IN ($search->keys)",
+                "SELECT info_hash, id topic_id FROM Topics WHERE info_hash IN ($search->keys)",
                 $search->values,
                 true,
                 PDO::FETCH_ASSOC | PDO::FETCH_UNIQUE

--- a/src/back/Settings.php
+++ b/src/back/Settings.php
@@ -143,10 +143,10 @@ final class Settings
 
         // отчёты
         $config['reports'] = [
+            'send_summary_report' => $ini->read('reports', 'send_summary_report', 1),
             'auto_clear_messages' => $ini->read('reports', 'auto_clear_messages', 0),
             'exclude_forums_ids'  => $ini->read('reports', 'exclude_forums_ids'),
             'exclude_clients_ids' => $ini->read('reports', 'exclude_clients_ids'),
-            'send_summary_report' => $ini->read('reports', 'common', 1),
         ];
 
         // автоматизация
@@ -458,6 +458,8 @@ final class Settings
         $ini->write('sections', 'exclude_self_keep', isset($cfg['exclude_self_keep']) ? 1 : 0);
 
 
+        // Отправка сводных отчётов на форум
+        $ini->write('reports', 'send_summary_report', isset($cfg['send_summary_report']) ? 1 : 0);
         // Очистка своих сообщений на форуме
         $ini->write('reports', 'auto_clear_messages', isset($cfg['auto_clear_messages']) ? 1 : 0);
 

--- a/src/back/TopicList/Rule/BlackListedTopics.php
+++ b/src/back/TopicList/Rule/BlackListedTopics.php
@@ -26,25 +26,22 @@ final class BlackListedTopics implements ListInterface
     /** Хранимые раздачи из других подразделов. */
     public function getTopics(array $filter, Sort $sort): Topics
     {
-        $statement = sprintf(
-            "
-                SELECT
-                    Topics.id AS topic_id,
-                    Topics.hs AS info_hash,
-                    Topics.na AS name,
-                    Topics.si AS size,
-                    Topics.rg AS reg_time,
-                    Topics.ss AS forum_id,
-                    Topics.pt AS priority,
-                    0 AS client_id,
-                    %s,
-                    TopicsExcluded.comment
-                FROM Topics
-                LEFT JOIN TopicsExcluded ON Topics.hs = TopicsExcluded.info_hash
-                WHERE TopicsExcluded.info_hash IS NOT NULL
-            ",
-            $this->cfg['avg_seeders'] ? '(se * 1.) / qt AS seed' : 'se AS seed'
-        );
+        $statement = "
+            SELECT
+                tp.id topic_id,
+                tp.info_hash,
+                tp.name,
+                tp.size,
+                tp.reg_time,
+                tp.forum_id,
+                tp.keeping_priority AS priority,
+                0 AS client_id,
+                tp.seeders / tp.seeders_updates_today AS seed,
+                te.comment
+            FROM Topics AS tp
+            LEFT JOIN TopicsExcluded AS te ON tp.info_hash = te.info_hash
+            WHERE te.info_hash IS NOT NULL
+        ";
 
         $topics = $this->selectSortedTopics($sort, $statement);
 

--- a/src/back/TopicList/Rule/DbHelperTrait.php
+++ b/src/back/TopicList/Rule/DbHelperTrait.php
@@ -6,6 +6,7 @@ namespace KeepersTeam\Webtlo\TopicList\Rule;
 
 use PDO;
 use Exception;
+use RuntimeException;
 
 trait DbHelperTrait
 {
@@ -14,12 +15,12 @@ trait DbHelperTrait
     {
         try {
             return $this->db->query(
-                'SELECT DISTINCT ss FROM Topics WHERE pt = ?',
+                'SELECT DISTINCT forum_id FROM Topics WHERE keeping_priority = ?',
                 [2],
                 PDO::FETCH_COLUMN
             );
-        } catch (Exception) {
-            return [];
+        } catch (Exception $e) {
+            throw new RuntimeException($e->getMessage());
         }
     }
 
@@ -27,8 +28,8 @@ trait DbHelperTrait
     {
         try {
             return (array)$this->db->queryRow($statement, $params);
-        } catch (Exception) {
-            return [];
+        } catch (Exception $e) {
+            throw new RuntimeException($e->getMessage());
         }
     }
 
@@ -36,8 +37,8 @@ trait DbHelperTrait
     {
         try {
             return $this->db->query($statement, $params, PDO::FETCH_ASSOC | PDO::FETCH_GROUP);
-        } catch (Exception) {
-            return [];
+        } catch (Exception $e) {
+            throw new RuntimeException($e->getMessage());
         }
     }
 }

--- a/src/back/TopicList/Rule/DuplicatedTopics.php
+++ b/src/back/TopicList/Rule/DuplicatedTopics.php
@@ -37,18 +37,18 @@ final class DuplicatedTopics implements ListInterface
 
         $statement = '
             SELECT
-                Topics.id AS topic_id,
-                Topics.hs AS info_hash,
-                Topics.na AS name,
-                Topics.si AS size,
-                Topics.rg AS reg_time,
-                Topics.ss AS forum_id,
-                Topics.pt AS priority,
+                Topics.id topic_id,
+                Topics.info_hash,
+                Topics.name,
+                Topics.size,
+                Topics.reg_time,
+                Topics.forum_id,
+                Topics.keeping_priority AS priority,
                 0 AS client_id,
                 ' . implode(',', $seedFilter->fields) . '
             FROM Topics
                 ' . implode(' ', $seedFilter->joins) . '
-            WHERE Topics.hs IN (SELECT info_hash FROM Torrents GROUP BY info_hash HAVING count(1) > 1)
+            WHERE Topics.info_hash IN (SELECT info_hash FROM Torrents GROUP BY info_hash HAVING count(1) > 1)
         ';
 
         $topics = $this->selectSortedTopics($sort, $statement);

--- a/src/back/TopicList/Rule/FilterTrait.php
+++ b/src/back/TopicList/Rule/FilterTrait.php
@@ -6,7 +6,8 @@ namespace KeepersTeam\Webtlo\TopicList\Rule;
 
 use KeepersTeam\Webtlo\Helper;
 use KeepersTeam\Webtlo\TopicList\Filter\Sort;
-use Exception;
+use Throwable;
+use RuntimeException;
 
 trait FilterTrait
 {
@@ -15,8 +16,8 @@ trait FilterTrait
     {
         try {
             $topics = $this->db->query($statement, $params);
-        } catch (Exception) {
-            $topics = [];
+        } catch (Throwable $e) {
+            throw new RuntimeException($e->getMessage());
         }
 
         return Helper::natsortField(

--- a/src/back/TopicList/Rule/UntrackedTopics.php
+++ b/src/back/TopicList/Rule/UntrackedTopics.php
@@ -30,20 +30,20 @@ final class UntrackedTopics implements ListInterface
         $statement = '
             SELECT
                 TopicsUntracked.id AS topic_id,
-                TopicsUntracked.hs AS info_hash,
-                TopicsUntracked.na AS name,
-                TopicsUntracked.si AS size,
-                TopicsUntracked.rg AS reg_time,
-                TopicsUntracked.ss AS forum_id,
-                TopicsUntracked.se AS seed,
+                TopicsUntracked.info_hash,
+                TopicsUntracked.name,
+                TopicsUntracked.size,
+                TopicsUntracked.reg_time,
+                TopicsUntracked.forum_id,
+                TopicsUntracked.seeders AS seed,
                 -1 AS days_seed,
                 Torrents.done,
                 Torrents.paused,
                 Torrents.error,
                 Torrents.client_id
             FROM TopicsUntracked
-            LEFT JOIN Torrents ON Torrents.info_hash = TopicsUntracked.hs
-            WHERE TopicsUntracked.hs IS NOT NULL
+            LEFT JOIN Torrents ON Torrents.info_hash = TopicsUntracked.info_hash
+            WHERE TopicsUntracked.info_hash IS NOT NULL
         ';
 
         $topics = $this->selectSortedTopics($sort, $statement);

--- a/src/back/TopicList/Topic.php
+++ b/src/back/TopicList/Topic.php
@@ -66,7 +66,10 @@ final class Topic
         $url  = sprintf('%s/forum/viewtopic.php?t=%d', $forum_address, $this->id);
         $size = convert_bytes($this->size);
 
-        return "<a href='$url' target='_blank'>$this->name</a> ($size)";
+        $pattern = /** @lang text */
+            "<a href='%s' target='_blank'>%s</a> (%s)";
+
+        return sprintf($pattern, $url, $this->name, $size);
     }
 
     public function getAverageSeed(): string

--- a/src/back/TopicList/Validate.php
+++ b/src/back/TopicList/Validate.php
@@ -202,12 +202,12 @@ final class Validate
 
             $fields[] = "$qt AS days_seed";
             $fields[] =
-                "CASE WHEN $qt IS 0 THEN (se * 1.) / qt ELSE ( se * 1. + $sum_se) / ( qt + $sum_qt) END AS seed";
+                "CASE WHEN $qt IS 0 THEN (seeders * 1.) / seeders_updates_today ELSE ( seeders * 1. + $sum_se) / ( seeders_updates_today + $sum_qt) END AS seed";
 
             $joins[] = 'LEFT JOIN Seeders ON Topics.id = Seeders.id';
         } else {
             $fields[] = '-1 AS days_seed';
-            $fields[] = 'Topics.se AS seed';
+            $fields[] = 'Topics.seeders / MAX(seeders_updates_today, 1) AS seed';
         }
 
         return new AverageSeed(

--- a/src/back/WebTLO.php
+++ b/src/back/WebTLO.php
@@ -78,7 +78,10 @@ final class WebTLO
 
     public function getReleaseLink(): string
     {
-        return sprintf('Web-TLO <a href="%s" target="_blank">%s</a>', $this->versionUrl(), $this->version);
+        $pattern = /** @lang text */
+            'Web-TLO <a href="%s" target="_blank">%s</a>';
+
+        return sprintf($pattern, $this->versionUrl(), $this->version);
     }
 
     public function getCommitLink(): string
@@ -87,12 +90,18 @@ final class WebTLO
             return '';
         }
 
-        return sprintf('<a class="version-sha" href="%s" target="_blank">#%s</a>', $this->commitUrl(), $this->sha);
+        $pattern = /** @lang text */
+            '<a class="version-sha" href="%s" target="_blank">#%s</a>';
+
+        return sprintf($pattern, $this->commitUrl(), $this->sha);
     }
 
     public function getWikiLink(): string
     {
-        return sprintf('<a href="%s" target="_blank">Web-TLO wiki</a>', $this->wiki);
+        $pattern = /** @lang text */
+            '<a href="%s" target="_blank">Web-TLO wiki</a>';
+
+        return sprintf($pattern, $this->wiki);
     }
 
     public function getInstallation(): string

--- a/src/index.php
+++ b/src/index.php
@@ -31,6 +31,8 @@ try {
     $tor_for_user = $cfg['tor_for_user'] == 1 ? "checked" : "";
     $enable_auto_apply_filter = $cfg['enable_auto_apply_filter'] == 1 ? "checked" : "";
     $exclude_self_keep = $cfg['exclude_self_keep'] == 1 ? "checked" : "";
+
+    $send_summary_report = $cfg['reports']['send_summary_report'] == 1 ? "checked" : "";
     $auto_clear_messages = $cfg['reports']['auto_clear_messages'] == 1 ? "checked" : "";
 
     // вставка option в select
@@ -1018,9 +1020,13 @@ function cfg_checkbox($cfg): Closure
                         </div>
                         <h2>Отправка отчётов</h2>
                         <div>
-                            <label class="label">
+                            <label class="label" title="Можно отключить отправку сводного отчёта. Отчёты по хранимым подразделам будут отправлены как обычно.">
+                                <input name="send_summary_report" type="checkbox" size="24" <?= $send_summary_report ?? '' ?> />
+                                Отправлять сводный отчёт
+                            </label>
+                            <label class="label" title="Посты с отчётами о нехранимых подразделах, Будут заменены на 'Не актуально'">
                                 <input name="auto_clear_messages" type="checkbox" size="24" <?= $auto_clear_messages ?? '' ?> />
-                                очищать свои неактуальные сообщения в рабочем подфоруме
+                                Очищать свои "неактуальные" сообщения в рабочем подфоруме
                             </label>
                             <h3>Список исключённых групп, см. настройки торрент-клиентов/подразделов:</h3>
                             <label class="label">

--- a/src/php/actions/add_topics_to_client.php
+++ b/src/php/actions/add_topics_to_client.php
@@ -41,7 +41,7 @@ try {
     foreach ($topicHashes as $topicHashes) {
         $placeholders = str_repeat('?,', count($topicHashes) - 1) . '?';
         $data = Db::query_database(
-            'SELECT ss, hs FROM Topics WHERE hs IN (' . $placeholders . ')',
+            'SELECT forum_id, info_hash FROM Topics WHERE info_hash IN (' . $placeholders . ')',
             $topicHashes,
             true,
             PDO::FETCH_GROUP | PDO::FETCH_COLUMN
@@ -167,7 +167,7 @@ try {
             // получаем идентификаторы раздач
             $placeholders = str_repeat('?,', count($downloadedTorrentFilesChunk) - 1) . '?';
             $topicIDsByHash = Db::query_database(
-                'SELECT hs, id FROM Topics WHERE hs IN (' . $placeholders . ')',
+                'SELECT info_hash, id FROM Topics WHERE info_hash IN (' . $placeholders . ')',
                 $downloadedTorrentFilesChunk,
                 true,
                 PDO::FETCH_KEY_PAIR
@@ -234,13 +234,13 @@ try {
                     total_size
                 )
                 SELECT
-                    Topics.hs,
+                    Topics.info_hash,
                     ?,
                     Topics.id,
-                    Topics.na,
-                    Topics.si
+                    Topics.name,
+                    Topics.size
                 FROM Topics
-                WHERE hs IN (' . $placeholders . ')',
+                WHERE info_hash IN (' . $placeholders . ')',
                 array_merge([$torrentClientID], $addedTorrentFiles)
             );
             unset($placeholders);

--- a/src/php/actions/get_filtered_list_topics.php
+++ b/src/php/actions/get_filtered_list_topics.php
@@ -68,5 +68,6 @@ try {
 } catch (Exception $e) {
     $returnObject['log'] = $e->getMessage();
 }
+$returnObject['details'] = Log::get();
 
 echo json_encode($returnObject, JSON_UNESCAPED_UNICODE);

--- a/src/php/actions/get_statistics.php
+++ b/src/php/actions/get_statistics.php
@@ -1,5 +1,7 @@
 <?php
 
+use KeepersTeam\Webtlo\DTO\KeysObject;
+
 $statistics_result = [
     'tbody' => '',
     'tfoot' => '',
@@ -17,49 +19,53 @@ try {
     $statistics = [];
     $forumsIDsChunks = array_chunk(array_keys($cfg['subsections']), 499);
 
+    $days30 = 30 * 24 * 60 * 60; // seconds
     foreach ($forumsIDsChunks as $forumsIDs) {
-        $placeholdersForumsIDs = str_repeat('?,', count($forumsIDs) - 1) . '?';
-        $sql = "SELECT
+        $forumChunk = KeysObject::create($forumsIDs);
+
+        $sql = "
+            SELECT
             f.id AS forum_id,
             f.name AS forum_name,
-            COUNT(CASE WHEN seeds.se = 0 THEN 1 ELSE NULL END) AS Count0,
-            SUM(CASE WHEN seeds.se = 0 THEN seeds.si ELSE 0 END) AS Size0,
-            COUNT(CASE WHEN seeds.se > 0 AND seeds.se <= 0.5 THEN 1 ELSE NULL END) AS Count5,
-            SUM(CASE WHEN seeds.se > 0 AND seeds.se <= 0.5 THEN seeds.si ELSE 0 END) AS Size5,
-            COUNT(CASE WHEN seeds.se > 0.5 AND seeds.se <= 1.0 THEN 1 ELSE NULL END) AS Count10,
-            SUM(CASE WHEN seeds.se > 0.5 AND seeds.se <= 1.0 THEN seeds.si ELSE 0 END) AS Size10,
-            COUNT(CASE WHEN seeds.se > 1.0 AND seeds.se <= 1.5 THEN 1 ELSE NULL END) AS Count15,
-            SUM(CASE WHEN seeds.se > 1.0 AND seeds.se <= 1.5 THEN seeds.si ELSE 0 END) AS Size15,
+            COUNT(CASE WHEN seeds.se = 0 THEN 1 END) AS Count0,
+            SUM(CASE WHEN seeds.se = 0 THEN seeds.size ELSE 0 END) AS Size0,
+            COUNT(CASE WHEN seeds.se > 0 AND seeds.se <= 0.5 THEN 1 END) AS Count5,
+            SUM(CASE WHEN seeds.se > 0 AND seeds.se <= 0.5 THEN seeds.size ELSE 0 END) AS Size5,
+            COUNT(CASE WHEN seeds.se > 0.5 AND seeds.se <= 1.0 THEN 1 END) AS Count10,
+            SUM(CASE WHEN seeds.se > 0.5 AND seeds.se <= 1.0 THEN seeds.size ELSE 0 END) AS Size10,
+            COUNT(CASE WHEN seeds.se > 1.0 AND seeds.se <= 1.5 THEN 1 END) AS Count15,
+            SUM(CASE WHEN seeds.se > 1.0 AND seeds.se <= 1.5 THEN seeds.size ELSE 0 END) AS Size15,
             f.quantity,
             f.size
             FROM Forums f
             LEFT JOIN (
                 SELECT
                     t.id,
-                    t.si,
-                    t.st,
-                    t.ss,
-                    (CAST((IFNULL(t.se, 0)+IFNULL(s.d0 , 0)+IFNULL(s.d1 , 0)+IFNULL(s.d2 , 0)+IFNULL(s.d3 , 0)+IFNULL(s.d4 , 0)+IFNULL(s.d5 , 0)+IFNULL(s.d6 , 0)+IFNULL(s.d7 , 0)+IFNULL(s.d8 , 0)+IFNULL(s.d9 , 0)+
+                    t.size,
+                    t.status,
+                    t.forum_id,
+                    (CAST((IFNULL(t.seeders, 0)+IFNULL(s.d0 , 0)+IFNULL(s.d1 , 0)+IFNULL(s.d2 , 0)+IFNULL(s.d3 , 0)+IFNULL(s.d4 , 0)+IFNULL(s.d5 , 0)+IFNULL(s.d6 , 0)+IFNULL(s.d7 , 0)+IFNULL(s.d8 , 0)+IFNULL(s.d9 , 0)+
                     IFNULL(s.d10, 0)+IFNULL(s.d11, 0)+IFNULL(s.d12, 0)+IFNULL(s.d13, 0)) as FLOAT)) /
-                    ((IFNULL(t.qt, 0)+IFNULL(s.q0 , 0)+IFNULL(s.q1 , 0)+IFNULL(s.q2 , 0)+IFNULL(s.q3 , 0)+IFNULL(s.q4 , 0)+IFNULL(s.q5 , 0)+IFNULL(s.q6 , 0)+IFNULL(s.q7 , 0)+IFNULL(s.q8 , 0)+IFNULL(s.q9 , 0)+
+                    ((IFNULL(t.seeders_updates_today, 0)+IFNULL(s.q0 , 0)+IFNULL(s.q1 , 0)+IFNULL(s.q2 , 0)+IFNULL(s.q3 , 0)+IFNULL(s.q4 , 0)+IFNULL(s.q5 , 0)+IFNULL(s.q6 , 0)+IFNULL(s.q7 , 0)+IFNULL(s.q8 , 0)+IFNULL(s.q9 , 0)+
                     IFNULL(s.q10, 0)+IFNULL(s.q11, 0)+IFNULL(s.q12, 0)+IFNULL(s.q13, 0))) AS se
                 FROM Topics t
                 LEFT JOIN Seeders s ON t.id = s.id
-                LEFT JOIN Torrents ON t.hs = Torrents.info_hash
+                LEFT JOIN Torrents ON t.info_hash = Torrents.info_hash
                 LEFT JOIN (SELECT topic_id, MAX(posted) as posted FROM KeepersLists WHERE complete = 1 GROUP BY topic_id) k ON t.id = k.topic_id
-                WHERE t.ss IN (" . $placeholdersForumsIDs . ")
-                    AND t.pt IN(1,2)
+                WHERE t.forum_id IN (" . $forumChunk->keys . ")
+                    AND t.keeping_priority IN (1,2)
                     AND Torrents.info_hash IS NULL
-                    AND strftime('%s', 'now') - t.rg >= 2592000
-                    AND (k.topic_id IS NULL OR strftime('%s', 'now') - k.posted >= 2592000)
-            ) AS seeds ON seeds.ss = f.id
-            WHERE f.id IN (" . $placeholdersForumsIDs . ")
-            GROUP BY f.id
-            ORDER BY LOWER(f.name)";
+                    AND t.reg_time <= unixepoch() - $days30
+                    AND (k.topic_id IS NULL OR k.posted <= unixepoch() - $days30)
+            ) AS seeds ON seeds.forum_id = f.id
+            WHERE f.id IN (" . $forumChunk->keys . ")
+            GROUP BY f.id, f.name
+            ORDER BY LOWER(f.name)
+        ";
 
         $data = Db::query_database(
             $sql,
-            array_merge($forumsIDs, $forumsIDs),
+            array_merge($forumChunk->values, $forumChunk->values),
             true
         );
 

--- a/src/php/classes/db.php
+++ b/src/php/classes/db.php
@@ -183,8 +183,8 @@ class Db
         // Удалим раздачи из подразделов, для которых нет актуальных меток обновления.
         self::query_database('
             DELETE FROM Topics
-            WHERE pt <> 2
-                AND ss NOT IN (SELECT id FROM UpdateTime WHERE id < 100000)
+            WHERE keeping_priority <> 2
+                AND forum_id NOT IN (SELECT id FROM UpdateTime WHERE id < 100000)
         ');
 
         // Если используется алгоритм получения раздач высокого приоритета - их тоже нужно чистить.
@@ -195,8 +195,8 @@ class Db
             if ($lastHighUpdate < $outdatedTime) {
                 self::query_database('
                     DELETE FROM Topics
-                    WHERE pt = 2
-                        AND ss NOT IN (SELECT id FROM UpdateTime WHERE id < 100000)
+                    WHERE keeping_priority = 2
+                        AND forum_id NOT IN (SELECT id FROM UpdateTime WHERE id < 100000)
                 ');
             }
         }

--- a/src/php/common/control.php
+++ b/src/php/common/control.php
@@ -84,13 +84,13 @@ foreach ($cfg['clients'] as $torrentClientID => $torrentClientData) {
     foreach ($torrentsHashes as $torrentsHashes) {
         $placeholdersTorrentsHashes = str_repeat('?,', count($torrentsHashes) - 1) . '?';
         $responseTopicsHashes = Db::query_database(
-            'SELECT
-                ss,
-                hs
-            FROM Topics
-            WHERE
-                hs IN (' . $placeholdersTorrentsHashes . ')
-                AND ss IN (' . $placeholdersForumsIDs . ')',
+            '
+                SELECT forum_id, info_hash
+                FROM Topics
+                WHERE
+                    info_hash IN (' . $placeholdersTorrentsHashes . ')
+                    AND forum_id IN (' . $placeholdersForumsIDs . ')
+            ',
             array_merge($torrentsHashes, $forumsIDs),
             true,
             PDO::FETCH_GROUP | PDO::FETCH_COLUMN

--- a/src/php/common/seeders.php
+++ b/src/php/common/seeders.php
@@ -1,17 +1,15 @@
 <?php
 
-$starttime = microtime(true);
+use KeepersTeam\Webtlo\DTO\KeysObject;
+use KeepersTeam\Webtlo\Module\CloneTable;
+use KeepersTeam\Webtlo\Module\LastUpdate;
+use KeepersTeam\Webtlo\Module\Topics;
 
 include_once dirname(__FILE__) . '/../common.php';
 include_once dirname(__FILE__) . '/../classes/api.php';
 
-Log::append("Начато обновление информации о сидах для всех раздач трекера...");
-
 // обновляем дерево подразделов
 include_once dirname(__FILE__) . '/forum_tree.php';
-
-// обновляем список высокоприоритетных раздач
-include_once dirname(__FILE__) . '/high_priority_topics.php';
 
 // получаем список подразделов
 $forums_ids = Db::query_database(
@@ -30,20 +28,6 @@ if (!isset($cfg)) {
     $cfg = get_settings();
 }
 
-// создаём временные таблицы
-Db::query_database(
-    "CREATE TEMP TABLE UpdateTimeNow AS
-    SELECT id,ud FROM UpdateTime WHERE 0 = 1"
-);
-Db::query_database(
-    "CREATE TEMP TABLE TopicsUpdate AS
-    SELECT id,ss,se,st,qt,ds,pt FROM Topics WHERE 0 = 1"
-);
-Db::query_database(
-    "CREATE TEMP TABLE TopicsRenew AS
-    SELECT id,ss,se,si,st,rg,qt,ds,pt FROM Topics WHERE 0 = 1"
-);
-
 // подключаемся к api
 if (!isset($api)) {
     $api = new Api($cfg['api_address'], $cfg['api_key']);
@@ -51,128 +35,152 @@ if (!isset($api)) {
     $api->setUserConnectionOptions($cfg['curl_setopt']['api']);
 }
 
-// все открытые раздачи
-$tor_status = [0, 2, 3, 8, 10];
+
+Timers::start('topics_update');
+Log::append("Начато обновление сведений о раздачах всех подразделов...");
+
+// Параметры таблиц.
+$tabTime = CloneTable::create('UpdateTime');
+// Обновляемые раздачи.
+$tabTopicsUpdate = CloneTable::create(
+    'Topics',
+    [
+        'id',
+        'forum_id',
+        'seeders',
+        'status',
+        'seeders_updates_today',
+        'seeders_updates_days',
+        'keeping_priority',
+        'poster',
+        'seeder_last_seen',
+    ],
+    'id',
+    'Update'
+);
+// Новые раздачи.
+$tabTopicsRenew = CloneTable::create(
+    'Topics',
+    [
+        'id',
+        'forum_id',
+        'name',
+        'info_hash',
+        'seeders',
+        'size',
+        'status',
+        'reg_time',
+        'seeders_updates_today',
+        'seeders_updates_days',
+        'keeping_priority',
+        'poster',
+        'seeder_last_seen',
+    ],
+    'id',
+    'Renew'
+);
 
 // время текущего и предыдущего обновления
-$current_update_time = new DateTime();
+$currentUpdateTime  = new DateTime();
 $previousUpdateTime = new DateTime();
 
-// всего раздач без сидов
-$total_topics_no_seeders = 0;
+$forumsUpdateTime = [];
+$noUpdateForums   = [];
+$subsections = array_keys($cfg['subsections'] ?? []);
 
-// всего перезалитых раздач
-$total_topics_delete = 0;
-
+// обновим каждый хранимый подраздел
 foreach ($forums_ids as $forum_id) {
-    // пропускаем хранимые подразделы
-    if (
-        isset($cfg['subsections'])
-        && array_key_exists($forum_id, $cfg['subsections'])
-    ) {
+    // Пропускаем хранимые подразделы/
+    if (in_array($forum_id, $subsections)) {
         continue;
     }
 
     // получаем дату предыдущего обновления
-    $update_time = Db::query_database(
-        "SELECT ud FROM UpdateTime WHERE id = ?",
-        [$forum_id],
-        true,
-        PDO::FETCH_COLUMN
-    );
-
-    // при первом обновлении
-    if (empty($update_time[0])) {
-        $update_time[0] = 0;
-    }
-
-    $time_diff = time() - $update_time[0];
+    $update_time = LastUpdate::getTime($forum_id);
 
     // если не прошёл час
-    if ($time_diff < 3600) {
-        Log::append("Notice: Не требуется обновление для подраздела № " . $forum_id);
+    if (time() - $update_time < 3600) {
+        $noUpdateForums[] = $forum_id;
         continue;
     }
 
+    Timers::start("update_forum_$forum_id");
     // получаем данные о раздачах
     $topics_data = $api->getForumTopicsData($forum_id);
-
     if (empty($topics_data['result'])) {
-        Log::append("Error: Не получены данные о подразделе № " . $forum_id);
+        Log::append("Error: Не получены данные о подразделе № $forum_id");
         continue;
     }
 
     // количество и вес раздач
     $topics_count = count($topics_data['result']);
-    $topics_size = $topics_data['total_size_bytes'];
-
-    // Log::append( "Список раздач подраздела № $forum_id получен ($topics_count шт.)" );
+    $topics_size  = $topics_data['total_size_bytes'];
+    $topic_keys   = $topics_data['format']['topic_id'];
 
     // запоминаем время обновления каждого подраздела
-    $forums_update_time[$forum_id]['ud'] = $topics_data['update_time'];
+    $forumsUpdateTime[$forum_id]['ud'] = $topics_data['update_time'];
 
     // текущее обновление в DateTime
-    $current_update_time->setTimestamp($topics_data['update_time']);
+    $currentUpdateTime->setTimestamp($topics_data['update_time']);
 
     // предыдущее обновление в DateTime
-    $previousUpdateTime->setTimestamp($update_time[0])->setTime(0, 0, 0);
+    $previousUpdateTime->setTimestamp($update_time)->setTime(0, 0);
 
     // разница в днях между обновлениями сведений
-    $daysDiffAdjusted = $current_update_time->diff($previousUpdateTime)->format('%d');
+    $daysDiffAdjusted = $currentUpdateTime->diff($previousUpdateTime)->format('%d');
 
     // разбиваем result по 500 раздач
-    $topics_result = array_chunk($topics_data['result'], 500, true);
-    unset($topics_data);
+    $topics_data = array_chunk($topics_data['result'], 500, true);
 
-    foreach ($topics_result as $topics_result) {
+    foreach ($topics_data as $topics_result) {
         // получаем данные о раздачах за предыдущее обновление
-        $topics_ids = array_keys($topics_result);
-        $in = str_repeat('?,', count($topics_ids) - 1) . '?';
+        $selectTopics = KeysObject::create(array_keys($topics_result));
         $topics_data_previous = Db::query_database(
-            "SELECT id,se,rg,qt,ds FROM Topics WHERE id IN ($in)",
-            $topics_ids,
+            "
+                SELECT id, seeders, reg_time, seeders_updates_today, seeders_updates_days
+                FROM Topics
+                WHERE id IN ($selectTopics->keys)
+            ",
+            $selectTopics->values,
             true,
             PDO::FETCH_ASSOC | PDO::FETCH_UNIQUE
         );
-        unset($topics_ids);
+        unset($selectTopics);
 
+        $topicsKeepersFromForum = [];
+        $dbTopicsKeepers = [];
+        $db_topics_renew = $db_topics_update = [];
         // разбираем раздачи
-        // topic_id => array( tor_status, seeders, reg_time, tor_size_bytes, keeping_priority )
-        foreach ($topics_result as $topic_id => $topic_data) {
-            if (empty($topic_data)) {
+        // topic_id => [tor_status, seeders, reg_time, tor_size_bytes, keeping_priority,
+        //              keepers, seeder_last_seen, info_hash, topic_poster]
+        foreach ($topics_result as $topic_id => $topic_raw) {
+            if (empty($topic_raw)) {
                 continue;
             }
 
-            if (count($topic_data) < 5) {
+            if (count($topic_raw) < 6) {
                 throw new Exception("Error: Недостаточно элементов в ответе");
             }
+            $topic_data = array_combine($topic_keys, $topic_raw);
+            unset($topic_raw);
 
-            if (
-                !in_array($topic_data[0], $tor_status)
-                || $topic_data[4] == 2
-            ) {
+            // Пропускаем раздачи в невалидных статусах. Или с высоким приоритетом.
+            if (!in_array($topic_data['tor_status'], Topics::VALID_STATUSES)) {
                 continue;
-            }
-
-            // считаем раздачи без сидов
-            if ($topic_data[1] == 0) {
-                $total_topics_no_seeders++;
             }
 
             $days_update = 0;
             $sum_updates = 1;
-            $sum_seeders = $topic_data[1];
+            $sum_seeders = $topic_data['seeders'];
 
             // запоминаем имеющиеся данные о раздаче в локальной базе
-            if (isset($topics_data_previous[$topic_id])) {
-                $previous_data = $topics_data_previous[$topic_id];
-            }
+            $previous_data = $topics_data_previous[$topic_id] ?? [];
 
-            // удалить перерегистрированную раздачу
+            // удалить перерегистрированную раздачу и раздачу с устаревшими сидами
             // в том числе, чтобы очистить значения сидов для старой раздачи
             if (
-                isset($previous_data['rg'])
-                && $previous_data['rg'] != $topic_data[2]
+                isset($previous_data['reg_time'])
+                && $previous_data['reg_time'] != $topic_data['reg_time']
             ) {
                 $topics_delete[] = $topic_id;
                 $isTopicDataDelete = true;
@@ -180,142 +188,129 @@ foreach ($forums_ids as $forum_id) {
                 $isTopicDataDelete = false;
             }
 
-            // получить для раздачи info_hash и topic_title
+            // Новая или обновлённая раздача
             if (
                 empty($previous_data)
                 || $isTopicDataDelete
             ) {
-                $db_topics_renew[$topic_id] = [
-                    'id' => $topic_id,
-                    'ss' => $forum_id,
-                    'se' => $sum_seeders,
-                    'si' => $topic_data[3],
-                    'st' => $topic_data[0],
-                    'rg' => $topic_data[2],
-                    'qt' => $sum_updates,
-                    'ds' => $days_update,
-                    'pt' => $topic_data[4],
-                ];
+                $db_topics_renew[$topic_id] = array_combine(
+                    $tabTopicsRenew->keys,
+                    [
+                        $topic_id,
+                        $forum_id,
+                        '',
+                        $topic_data['info_hash'],
+                        $sum_seeders,
+                        $topic_data['tor_size_bytes'],
+                        $topic_data['tor_status'],
+                        $topic_data['reg_time'],
+                        $sum_updates,
+                        $days_update,
+                        $topic_data['keeping_priority'],
+                        $topic_data['topic_poster'],
+                        $topic_data['seeder_last_seen'],
+                    ]
+                );
                 unset($previous_data);
                 continue;
             }
 
             // алгоритм нахождения среднего значения сидов
             if ($cfg['avg_seeders']) {
-                $days_update = $previous_data['ds'];
+                $days_update = $previous_data['seeders_updates_days'];
                 // по прошествии дня
                 if ($daysDiffAdjusted > 0) {
                     $days_update++;
                 } else {
-                    $sum_updates += $previous_data['qt'];
-                    $sum_seeders += $previous_data['se'];
+                    $sum_updates += $previous_data['seeders_updates_today'];
+                    $sum_seeders += $previous_data['seeders'];
                 }
             }
             unset($previous_data);
 
-            $db_topics_update[$topic_id] = [
-                'id' => $topic_id,
-                'ss' => $forum_id,
-                'se' => $sum_seeders,
-                'st' => $topic_data[0],
-                'qt' => $sum_updates,
-                'ds' => $days_update,
-                'pt' => $topic_data[4],
-            ];
+            $db_topics_update[$topic_id] = array_combine(
+                $tabTopicsUpdate->keys,
+                [
+                    $topic_id,
+                    $forum_id,
+                    $sum_seeders,
+                    $topic_data['tor_status'],
+                    $sum_updates,
+                    $days_update,
+                    $topic_data['keeping_priority'],
+                    $topic_data['topic_poster'],
+                    $topic_data['seeder_last_seen'],
+                ]
+            );
+
+            unset($topic_id, $topic_data);
         }
-        unset($topics_data_previous);
+        unset($topics_result, $topics_data_previous);
 
         // вставка данных в базу о новых раздачах
-        if (isset($db_topics_renew)) {
-            $select = Db::combine_set($db_topics_renew);
-            unset($db_topics_renew);
-            Db::query_database("INSERT INTO temp.TopicsRenew $select");
-            unset($select);
+        if (count($db_topics_renew)) {
+            $tabTopicsRenew->cloneFill($db_topics_renew);
         }
         unset($db_topics_renew);
 
         // обновление данных в базе о существующих раздачах
-        if (isset($db_topics_update)) {
-            $select = Db::combine_set($db_topics_update);
-            unset($db_topics_update);
-            Db::query_database("INSERT INTO temp.TopicsUpdate $select");
-            unset($select);
+        if (count($db_topics_update)) {
+            $tabTopicsUpdate->cloneFill($db_topics_update);
         }
         unset($db_topics_update);
     }
-    unset($topics_result);
+    unset($topics_data);
+
+    Log::append(sprintf(
+        'Обновление списка раздач подраздела № %d завершено за %s, %d шт',
+        $forum_id,
+        Timers::getExecTime("update_forum_$forum_id"),
+        $topics_count
+    ));
+}
+
+if (count($noUpdateForums)) {
+    Log::append(sprintf(
+        'Notice: Обновление списков раздач не требуется для подразделов №№ %s.',
+        implode(', ', $noUpdateForums)
+    ));
 }
 
 // удаляем перерегистрированные раздачи
 // чтобы очистить значения сидов для старой раздачи
 if (isset($topics_delete)) {
-    $total_topics_delete = count($topics_delete);
-    $topics_delete = array_chunk($topics_delete, 500);
-    foreach ($topics_delete as $topics_delete) {
-        $in = str_repeat('?,', count($topics_delete) - 1) . '?';
-        Db::query_database(
-            "DELETE FROM Topics WHERE id IN ($in)",
-            $topics_delete
-        );
-    }
+    Topics::deleteTopicsByIds($topics_delete);
+    unset($topics_delete);
 }
 
-$count_update = Db::query_database(
-    "SELECT COUNT() FROM temp.TopicsUpdate",
-    [],
-    true,
-    PDO::FETCH_COLUMN
-);
-$count_renew = Db::query_database(
-    "SELECT COUNT() FROM temp.TopicsRenew",
-    [],
-    true,
-    PDO::FETCH_COLUMN
-);
 
-if (
-    $count_update[0] > 0
-    || $count_renew[0] > 0
-) {
+$countTopicsUpdate = $tabTopicsUpdate->cloneCount();
+$countTopicsRenew  = $tabTopicsRenew->cloneCount();
+if ($countTopicsUpdate > 0 || $countTopicsRenew > 0) {
     // переносим данные в основную таблицу
-    Db::query_database(
-        "INSERT INTO Topics (id,ss,se,st,qt,ds,pt)
-        SELECT * FROM temp.TopicsUpdate"
-    );
-    Db::query_database(
-        "INSERT INTO Topics (id,ss,se,si,st,rg,qt,ds,pt)
-        SELECT * FROM temp.TopicsRenew"
-    );
-    $forums_ids = array_keys($forums_update_time);
+    $tabTopicsUpdate->moveToOrigin();
+    $tabTopicsRenew->moveToOrigin();
+
+    $forums_ids = array_keys($forumsUpdateTime);
     $in = implode(',', $forums_ids);
-    Db::query_database(
-        "DELETE FROM Topics WHERE id IN (
-            SELECT Topics.id FROM Topics
-            LEFT JOIN temp.TopicsUpdate ON Topics.id = temp.TopicsUpdate.id
-            LEFT JOIN temp.TopicsRenew ON Topics.id = temp.TopicsRenew.id
-            WHERE temp.TopicsUpdate.id IS NULL AND temp.TopicsRenew.id IS NULL AND Topics.ss IN ($in) AND Topics.pt <> 2
-        )"
-    );
+    Db::query_database("
+        DELETE FROM Topics
+        WHERE id IN (
+            SELECT Topics.id
+            FROM Topics
+            LEFT JOIN $tabTopicsUpdate->clone tpu ON Topics.id = tpu.id
+            LEFT JOIN $tabTopicsRenew->clone tpr ON Topics.id = tpr.id
+            WHERE tpu.id IS NULL AND tpr.id IS NULL AND Topics.forum_id IN ($in)
+        )
+    ");
     // время последнего обновления для каждого подраздела
-    $totalUpdatedForums = count($forums_update_time);
-    $forums_update_time = array_chunk($forums_update_time, 500, true);
-    foreach ($forums_update_time as $forums_update_time) {
-        $select = Db::combine_set($forums_update_time);
-        Db::query_database("INSERT INTO temp.UpdateTimeNow $select");
-        unset($select);
-    }
-    Db::query_database(
-        "INSERT INTO UpdateTime (id,ud)
-        SELECT id,ud FROM temp.UpdateTimeNow"
-    );
-    $total_topics_update = $count_update[0] + $count_renew[0];
-    Log::append("Обработано подразделов: " . $totalUpdatedForums . " шт.");
-    Log::append("Обработано раздач: " . $total_topics_update . " шт.");
-    Log::append("Раздач без сидов: " . $total_topics_no_seeders . " шт.");
-    Log::append("Перезалитых раздач: " . $total_topics_delete . " шт.");
-    // Log::append("Запись в базу данных сведений о раздачах...");
+    $tabTime->cloneFillChunk($forumsUpdateTime);
+    $tabTime->moveToOrigin();
+
+    Log::append(sprintf(
+        'Обработано подразделов: %d шт, раздач в них %d',
+        count($forumsUpdateTime),
+        $countTopicsUpdate + $countTopicsRenew
+    ));
 }
-
-$endtime = microtime(true);
-
-Log::append("Обновление информации о сидах для всех раздач трекера завершено за " . convert_seconds($endtime - $starttime));
+Log::append("Обновление сведений о раздачах завершено за " . Timers::getExecTime('topics_update'));

--- a/src/php/common/tor_clients.php
+++ b/src/php/common/tor_clients.php
@@ -49,7 +49,7 @@ $tabTorrents = CloneTable::create(
 // Таблица хранимых раздач из других подразделов.
 $tabUntracked = CloneTable::create(
     'TopicsUntracked',
-    ['id','ss','na','hs','se','si','st','rg']
+    ['id','forum_id','name','info_hash','seeders','size','status','reg_time'],
 );
 
 // Таблица хранимых раздач, более не зарегистрированных на трекере.
@@ -253,10 +253,10 @@ if ($cfg['update']['untracked'] && $cfg['update']['unregistered']) {
                 Torrents.topic_id
             FROM Torrents
             LEFT JOIN Topics ON Topics.hs = Torrents.info_hash
-            LEFT JOIN TopicsUntracked ON TopicsUntracked.hs = Torrents.info_hash
+            LEFT JOIN TopicsUntracked ON TopicsUntracked.info_hash = Torrents.info_hash
             WHERE
                 Topics.hs IS NULL
-                AND TopicsUntracked.hs IS NULL
+                AND TopicsUntracked.info_hash IS NULL
                 AND Torrents.topic_id <> ''",
         [],
         true,

--- a/src/sql/0013-rename-topics-columns.sql
+++ b/src/sql/0013-rename-topics-columns.sql
@@ -1,0 +1,149 @@
+-- Переименуем названия ячеек таблицы TopicsUntracked.
+ALTER TABLE TopicsUntracked RENAME COLUMN ss TO forum_id;
+ALTER TABLE TopicsUntracked RENAME COLUMN na TO name;
+ALTER TABLE TopicsUntracked RENAME COLUMN hs TO info_hash;
+ALTER TABLE TopicsUntracked RENAME COLUMN se TO seeders;
+ALTER TABLE TopicsUntracked RENAME COLUMN si TO size;
+ALTER TABLE TopicsUntracked RENAME COLUMN st TO status;
+ALTER TABLE TopicsUntracked RENAME COLUMN rg TO reg_time;
+
+
+-- Удаляем существующие триггеры по таблице Topics.
+DROP TRIGGER IF EXISTS topic_exists;
+DROP TRIGGER IF EXISTS topics_delete;
+DROP TRIGGER IF EXISTS seeders_insert;
+DROP TRIGGER IF EXISTS seeders_transfer;
+
+-- Создаём таблицу заново и переносим данные.
+ALTER TABLE Topics RENAME TO Topics_old;
+
+CREATE TABLE IF NOT EXISTS Topics
+(
+    id                    INT PRIMARY KEY NOT NULL,
+    forum_id              INT,      -- Ид Подраздела
+    name                  VARCHAR,  -- Название раздачи
+    info_hash             VARCHAR,  -- Хеш раздачи
+    seeders               INT,      -- Симмарное количество сидов за сегодня
+    size                  INT,      -- Размер раздачи (байт)
+    status                INT,      -- Статус раздачи на форуме
+    reg_time              INT,      -- Дата регистрации
+    seeders_updates_today INT,      -- Количество обновлений за сегодня
+    seeders_updates_days  INT,      -- Количество дней обновлений
+    keeping_priority      INT,      -- Приоритет хранения
+    poster                INT DEFAULT 0,    -- Автор раздачи
+    seeder_last_seen      INT DEFAULT 0     -- Последняя доступность сида
+);
+
+CREATE INDEX IF NOT EXISTS IX_Topics_forum_hash ON Topics (forum_id, info_hash);
+
+INSERT INTO Topics SELECT * FROM Topics_old;
+
+-- Удаляем старую таблицу.
+DROP TABLE Topics_old;
+
+-- Создаём триггеры заново.
+CREATE TRIGGER IF NOT EXISTS topic_exists
+    BEFORE INSERT ON Topics
+    WHEN EXISTS (SELECT id FROM Topics WHERE id = NEW.id)
+BEGIN
+    UPDATE Topics
+    SET forum_id              = COALESCE(NEW.forum_id, forum_id),
+        name                  = COALESCE(NEW.name, name),
+        info_hash             = COALESCE(NEW.info_hash, info_hash),
+        seeders               = COALESCE(NEW.seeders, seeders),
+        size                  = COALESCE(NEW.size, size),
+        status                = COALESCE(NEW.status, status),
+        reg_time              = COALESCE(NEW.reg_time, reg_time),
+        seeders_updates_today = COALESCE(NEW.seeders_updates_today, seeders_updates_today),
+        seeders_updates_days  = COALESCE(NEW.seeders_updates_days, seeders_updates_days),
+        keeping_priority      = COALESCE(NEW.keeping_priority, keeping_priority),
+        poster                = CASE WHEN NEW.poster = 0 THEN poster ELSE NEW.poster END,
+        seeder_last_seen      = MAX(NEW.seeder_last_seen, seeder_last_seen)
+    WHERE id = NEW.id;
+    SELECT RAISE(IGNORE);
+END;
+
+
+CREATE TRIGGER IF NOT EXISTS topic_delete
+    AFTER DELETE ON Topics FOR EACH ROW
+BEGIN
+    DELETE FROM Seeders WHERE id = OLD.id;
+END;
+
+
+CREATE TRIGGER IF NOT EXISTS seeders_insert
+    AFTER INSERT ON Topics
+BEGIN
+    INSERT INTO Seeders (id) VALUES (NEW.id);
+END;
+
+
+CREATE TRIGGER IF NOT EXISTS seeders_transfer
+    AFTER UPDATE ON Topics WHEN NEW.seeders_updates_days <> OLD.seeders_updates_days
+BEGIN
+    UPDATE Seeders
+    SET d0  = OLD.seeders,
+        d1  = d0,
+        d2  = d1,
+        d3  = d2,
+        d4  = d3,
+        d5  = d4,
+        d6  = d5,
+        d7  = d6,
+        d8  = d7,
+        d9  = d8,
+        d10 = d9,
+        d11 = d10,
+        d12 = d11,
+        d13 = d12,
+        d14 = d13,
+        d15 = d14,
+        d16 = d15,
+        d17 = d16,
+        d18 = d17,
+        d19 = d18,
+        d20 = d19,
+        d21 = d20,
+        d22 = d21,
+        d23 = d22,
+        d24 = d23,
+        d25 = d24,
+        d26 = d25,
+        d27 = d26,
+        d28 = d27,
+        d29 = d28,
+        q0  = OLD.seeders_updates_today,
+        q1  = q0,
+        q2  = q1,
+        q3  = q2,
+        q4  = q3,
+        q5  = q4,
+        q6  = q5,
+        q7  = q6,
+        q8  = q7,
+        q9  = q8,
+        q10 = q9,
+        q11 = q10,
+        q12 = q11,
+        q13 = q12,
+        q14 = q13,
+        q15 = q14,
+        q16 = q15,
+        q17 = q16,
+        q18 = q17,
+        q19 = q18,
+        q20 = q19,
+        q21 = q20,
+        q22 = q21,
+        q23 = q22,
+        q24 = q23,
+        q25 = q24,
+        q26 = q25,
+        q27 = q26,
+        q28 = q27,
+        q29 = q28
+    WHERE id = NEW.id;
+END;
+
+-- Обновляем версию БД.
+PRAGMA user_version = 13;


### PR DESCRIPTION
* Переименованы названия полей таблиц `Topics` и `TopicsUntracked`, обновлён использующий их код, close #276.
* В "Настройки -> Отправка отчётов" добавлен новый пункт "Отправлять сводный отчёт", который позволяет отключить его отправку (опция ранее была только в конфиге).
* Исправлен алгоритм определения даты списка другого хранителя, в соответствии с алгоритмом подсчёта общей статистики. Теперь это максимальная из трёх дат:
  * Дата публикации поста
  * Дата редактирования поста
  * Дата "Актуально на N"
* В ошибку, которая может возникнуть при попытке сформировать/отправить отчёт, добавлено текстовое описание конкретных недостающих маркеров обновления, которые следует выполнить.