### PR TITLE
Исправить получение ссылки на новый релиз

### DIFF
--- a/src/scripts/jquery.common.js
+++ b/src/scripts/jquery.common.js
@@ -270,8 +270,8 @@ function selectBlockText(e) {
 
 // проверить наличие новой версии
 function checkNewVersion() {
-    var current_version = $("title").text().split("-")[2];
-    var new_version_last_checked = Cookies.get("new-version-last-checked");
+    const current_version = $("title").text().split("-")[2];
+    const new_version_last_checked = Cookies.get("new-version-last-checked");
     if (
         new_version_last_checked !== undefined
         && ($.now() - new_version_last_checked) <= 60000
@@ -285,16 +285,19 @@ function checkNewVersion() {
         }
         return;
     }
+
     $.ajax({
         type: "POST",
         url: "php/actions/check_new_version.php",
         success: function (response) {
             $("#log").append(response.log);
             response = $.parseJSON(response);
+
             Cookies.set("new-version-number", response.newVersionNumber);
             Cookies.set("new-version-link", response.newVersionLink);
             Cookies.set("new-version-whats-new", response.whatsNew);
             Cookies.set("new-version-last-checked", $.now());
+
             if (versionCompare(current_version, response.newVersionNumber) < 0) {
                 showNewVersion(response.newVersionNumber, response.newVersionLink, response.whatsNew)
             }
@@ -315,19 +318,22 @@ function showNewVersion(newVersionNumber, newVersionLink, whatsNew) {
     $("#new_version_description")
         .attr("title", whatsNew)
         .text("Доступна новая версия: ")
-        .append('<a id="new_version_link" href="' + newVersionLink + '">' + newVersionNumber + "</a>");
+        .append(`<a id="new_version_link" target="_blank" href="${newVersionLink}">v${newVersionNumber}</a>`);
+
     $("#new_version_available").show();
 }
 
 // http://stackoverflow.com/a/6832721/50079
 function versionCompare(v1, v2, options) {
-    var lexicographical = options && options.lexicographical,
+    let lexicographical = options && options.lexicographical,
         zeroExtend = options && options.zeroExtend,
         v1parts = v1.split('.'),
         v2parts = v2.split('.');
+
     function isValidPart(x) {
         return (lexicographical ? /^\d+[A-Za-z]*$/ : /^\d+$/).test(x);
     }
+
     if (!v1parts.every(isValidPart) || !v2parts.every(isValidPart)) {
         return NaN;
     }
@@ -339,12 +345,11 @@ function versionCompare(v1, v2, options) {
         v1parts = v1parts.map(Number);
         v2parts = v2parts.map(Number);
     }
-    for (var i = 0; i < v1parts.length; ++i) {
-        if (v2parts.length == i) {
+    for (let i = 0; i < v1parts.length; ++i) {
+        if (v2parts.length === i) {
             return 1;
         }
-
-        if (v1parts[i] == v2parts[i]) {
+        if (v1parts[i] === v2parts[i]) {
             continue;
         }
         else if (v1parts[i] > v2parts[i]) {
@@ -354,7 +359,7 @@ function versionCompare(v1, v2, options) {
             return -1;
         }
     }
-    if (v1parts.length != v2parts.length) {
+    if (v1parts.length !== v2parts.length) {
         return -1;
     }
     return 0;


### PR DESCRIPTION
Проверка новой версии теперь получает ссылку на конкретный релиз, в зависимости от типа установки.
`standalone` => `weblto-win-*.zip`
`zip` => `webtlo.zip`
В прочих случаях просто ссылка на релиз.

Close #293 