### PR TITLE
Forum Auth. Добавил использование прокси при получении изображения капчи

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -753,3 +753,18 @@ ul.about-installation
         transform: rotate(360deg);
     }
 }
+
+/*Диалог авторизации*/
+#auth_dialog {
+    display: none;
+    width: 400px;
+}
+
+#auth_dialog label.param-name {
+    width: 80px;
+}
+
+#auth_dialog img.captcha-image {
+    font-size: 0.7em;
+    font-style: italic;
+}

--- a/src/index.php
+++ b/src/index.php
@@ -1217,7 +1217,29 @@ function cfg_checkbox($cfg): Closure
             </div>
         </div>
     </div>
+
     <div id="dialog" title="Сообщение"></div>
+    <div id="auth_dialog" title="Авторизация на форуме">
+        <span class="text-danger">
+            Вы видите это сообщение, потому что ввели неправильное имя пользователя или пароль
+        </span>
+        <hr/>
+        Введите правильные данные для авторизации и нажмите "ОК"
+        <br/><br/>
+        <label class="param-name" for="tracker_username_correct">Логин:</label>
+        <input type="text" class="myinput" id="tracker_username_correct"/>
+        <br/>
+        <label class="param-name" for="tracker_password_correct">Пароль:</label>
+        <input type="text" class="myinput" id="tracker_password_correct" />
+        <br/><br/>
+        <div>
+            <input class="myinput" type="hidden" id="cap_fields" />
+            Введите текст с картинки (латиницей):
+            <img class="captcha-image" src="" alt="Если вы видите данный текст, то загрузить изображение капчи не удалось"/>
+        </div>
+        <input id="cap_code" size="10" title="Введите текст с картинки (латиницей)" />
+    </div>
+
     <!-- скрипты webtlo -->
     <script type="text/javascript" src="scripts/jquery.common.js"></script>
     <script type="text/javascript" src="scripts/jquery.topics.func.js"></script>

--- a/src/php/actions/get_user_details.php
+++ b/src/php/actions/get_user_details.php
@@ -22,9 +22,10 @@ try {
     }
 
     // капча
+    $cap_fields = [];
     if (
-        isset($_POST['cap_code'])
-        && isset($_POST['cap_fields'])
+        !empty($_POST['cap_code'])
+        && !empty($_POST['cap_fields'])
     ) {
         $cap_code = $_POST['cap_code'];
         $cap_fields = explode(',', $_POST['cap_fields']);
@@ -32,9 +33,7 @@ try {
             $cap_fields[0] => $cap_fields[1],
             $cap_fields[2] => $cap_code,
         ];
-    } else {
-        $cap_fields = [];
-    }
+    };
 
     // параметры прокси
     $activate_forum = !empty($cfg['proxy_activate_forum']) ? 1 : 0;

--- a/src/scripts/jquery.actions.js
+++ b/src/scripts/jquery.actions.js
@@ -218,7 +218,7 @@ $(document).ready(function () {
         const cap_code = $("#cap_code").val();
         const cap_fields = $("#cap_fields").val();
 
-        let dialog = $('#dialog');
+        let dialog = $('#auth_dialog');
         let authResult = $('#forum_auth_result');
         $.ajax({
             type: "POST",
@@ -235,16 +235,27 @@ $(document).ready(function () {
                 if (!$.isEmptyObject(response.captcha)) {
                     authResult.removeAttr("class").addClass("fa fa-circle text-danger");
 
-                    let capFields = response.captcha.join(',');
-                    let curLogin = $("#tracker_username").val();
-                    let curPass  = $("#tracker_password").val();
+                    let currentLogin = $('#tracker_username').val();
+                    let currentPass  = $('#tracker_password').val();
+                    dialog.find('#tracker_username_correct').val(currentLogin);
+                    dialog.find('#tracker_password_correct').val(currentPass);
+
+                    dialog.find('#cap_fields').val(response.captcha.join(','));
+                    dialog.find('img.captcha-image').prop('src', response.captcha_path);
 
                     dialog.dialog(
                         {
+                            width: 500,
                             buttons: [
                                 {
                                     text: "OK",
                                     click: function () {
+                                        let capCode = $('#cap_code');
+                                        if (!capCode.val().length) {
+                                            capCode.highlight();
+                                            return;
+                                        }
+
                                         let username_correct = $("#tracker_username_correct").val();
                                         let password_correct = $("#tracker_password_correct").val();
                                         $("#tracker_username").val(username_correct);
@@ -257,13 +268,7 @@ $(document).ready(function () {
                             modal: true,
                             resizable: false,
                         }
-                    ).html('<span class="text-danger">Вы видите это сообщение, потому что ввели неверные логин и/или пароль</span><br /><br />' +
-                        'Введите правильные данные для авторизации на форуме RuTracker.org ниже и нажмите "ОК"<br /><br />' +
-                        `Логин: <input type="text" class="myinput" id="tracker_username_correct" value="${curLogin}"/><br />` +
-                        `Пароль: <input class="myinput" type="text" id="tracker_password_correct" value="${curPass}"/><br /><br />` +
-                        `Введите текст с картинки: <input class="myinput" type="hidden" id="cap_fields" value="${capFields}" />` +
-                        `<div><img src="${response.captcha_path}" /></div>` +
-                        '<input id="cap_code" size="27" />');
+                    );
                     dialog.dialog("open");
                 } else {
                     authResult.removeAttr("class");


### PR DESCRIPTION
Т.к. статический поддомен форума заблокирован, у многих людей проблемы с авторизацией из-за невозможности получить картинку с капчой.

Продолжая #249, добавил использование прокси в алгоритм получения картинки с капчой при неудачной попытке акторизации. Теперь, если без прокси картинку получить не дуалось, будет вторая попытка уже с прокси.

Саму картинку теперь локально не храним, а выводим на фронт в виде base64 кодированной строки.