### PR TITLE
Add pushing to GH Container Registry

### DIFF
--- a/.github/workflows/sub-build-docker.yml
+++ b/.github/workflows/sub-build-docker.yml
@@ -62,6 +62,13 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and push
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/sub-build-docker.yml
+++ b/.github/workflows/sub-build-docker.yml
@@ -40,7 +40,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ inputs.REGISTRY_IMAGE }}
+          images: |
+            ${{ inputs.REGISTRY_IMAGE }}
+            ghcr.io/${{ github.repository }}
           tags: |
             type=schedule
             type=ref,event=branch

--- a/.github/workflows/sub-build-docker.yml
+++ b/.github/workflows/sub-build-docker.yml
@@ -76,6 +76,7 @@ jobs:
         with:
           context: .
           push: true
+          provenance: false
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
It's unclear whether GHCR login username should be `github.actor` or `github.repository_owner` - looks like real auth being done via GITHUB_TOKEN