### PR TITLE
Keepers. Add exluded list

### DIFF
--- a/src/back/Settings.php
+++ b/src/back/Settings.php
@@ -192,6 +192,8 @@ final class Settings
             'keepers_load_api'    => $ini->read('reports', 'keepers_load_api', 1),
             'exclude_forums_ids'  => $ini->read('reports', 'exclude_forums_ids'),
             'exclude_clients_ids' => $ini->read('reports', 'exclude_clients_ids'),
+            // Список игнорируемых хранителей
+            'exclude_keepers_ids' => $ini->read('reports', 'exclude_keepers_ids'),
         ];
 
         // автоматизация

--- a/src/back/Tables/KeepersSeeders.php
+++ b/src/back/Tables/KeepersSeeders.php
@@ -7,11 +7,14 @@ namespace KeepersTeam\Webtlo\Tables;
 use KeepersTeam\Webtlo\External\Api\V1\KeeperData;
 use KeepersTeam\Webtlo\Legacy\Db;
 use KeepersTeam\Webtlo\Module\CloneTable;
+use KeepersTeam\Webtlo\Update\ExcludedKeepersTrait;
 use Psr\Log\LoggerInterface;
 
 /** Таблица раздач, которые сидируют Хранители. */
 final class KeepersSeeders
 {
+    use ExcludedKeepersTrait;
+
     // Параметры таблицы
     private const TABLE   = 'KeepersSeeders';
     private const PRIMARY = 'topic_id';
@@ -54,6 +57,11 @@ final class KeepersSeeders
     public function addKeptTopic(int $topicId, array $keepers): void
     {
         foreach ($keepers as $keeperId) {
+            // Пропускаем игнорируемых хранителей.
+            if (in_array($keeperId, $this->excludedKeepers, true)) {
+                continue;
+            }
+
             $keeper = $this->getKeeperInfo($keeperId);
             if (null !== $keeper) {
                 $this->keptTopics[] = [$topicId, $keeper->keeperId, $keeper->keeperName];

--- a/src/back/Update/ExcludedKeepersTrait.php
+++ b/src/back/Update/ExcludedKeepersTrait.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KeepersTeam\Webtlo\Update;
+
+trait ExcludedKeepersTrait
+{
+    /** @var int[] */
+    protected array $excludedKeepers = [];
+
+    /**
+     * @param int[] $excluded
+     * @return void
+     */
+    public function setExcludedKeepers(array $excluded): void
+    {
+        $this->excludedKeepers = $excluded;
+    }
+
+    /**
+     * @param <string, mixed>[] $config
+     * @return int[]
+     */
+    public static function getExcludedKeepersList(array $config): array
+    {
+        $excludedKeepers = preg_replace('/[^0-9]/', '|', $config['reports']['exclude_keepers_ids'] ?? '');
+        $excludedKeepers = explode('|', $excludedKeepers);
+
+        return array_map(fn($el) => (int)$el, array_filter($excludedKeepers));
+    }
+}

--- a/src/back/Update/KeepersReports.php
+++ b/src/back/Update/KeepersReports.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace KeepersTeam\Webtlo\Update;
 
-use Exception;
 use KeepersTeam\Webtlo\Enum\UpdateStatus;
 use KeepersTeam\Webtlo\External\Api\V1\ApiError;
 use KeepersTeam\Webtlo\External\ApiClient;
@@ -19,6 +18,8 @@ use Throwable;
 
 final class KeepersReports
 {
+    use ExcludedKeepersTrait;
+
     public function __construct(
         private readonly ApiClient       $apiClient,
         private readonly ApiReportClient $apiReport,
@@ -29,7 +30,8 @@ final class KeepersReports
     }
 
     /**
-     * @throws Exception
+     * @param <string, mixed>[] $cfg
+     * @return bool
      */
     public function update(array $cfg): bool
     {
@@ -85,6 +87,11 @@ final class KeepersReports
                 }
 
                 foreach ($forumReports->keepers as $keeperReport) {
+                    // Пропускаем игнорируемых хранителей.
+                    if (in_array($keeperReport->keeperId, $this->excludedKeepers, true)) {
+                        continue;
+                    }
+
                     /** Данные о хранителе. */
                     $keeper = $this->keepers->getKeeperInfo($keeperReport->keeperId);
 

--- a/src/back/Update/Subsections.php
+++ b/src/back/Update/Subsections.php
@@ -96,6 +96,13 @@ final class Subsections
             return;
         }
 
+        // Находим список игнорируемых хранителей.
+        $excludedKeepers = KeepersSeeders::getExcludedKeepersList($config);
+        $this->keepersSeeders->setExcludedKeepers($excludedKeepers);
+        if (count($excludedKeepers)) {
+            $this->logger->debug('KeepersSeeders. Исключены хранители', $excludedKeepers);
+        }
+
         $tabUpdateTime = $this->updateTime;
 
         // Обновим каждый хранимый подраздел.


### PR DESCRIPTION
close #272

Добавлена опция в конфиг, в значение которой можно перечислить id хранителей, которых нужно исключить из локальных данных.

Указанные хранители не будут отображаться в списке раздач, не будут учитываться в количестве хранителей раздачи и вообще не будут присутствовать в локальной БД.

На текущий момент, заполнение вручную. Найти секцию  `reports` в `config.ini`, внести ид через запятую или `|`. 
Например:
```
[reports]
exclude_keepers_ids="1234,4312,3212"
```