### PR TITLE
Добавлены ссылки на профиль хранителя и выбранный хранимый подраздел из настроек

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -649,6 +649,16 @@ div.toolbar-buttons > button.ui-button {
     padding: 5px;
 }
 
+#table_statistics td:nth-child(2) {
+    text-align: left;
+}
+
+td.statistic-forum-id {
+    cursor: pointer;
+    text-decoration-line: underline;
+    text-decoration-color: darkblue;
+}
+
 .warning {
     background: #fafa00;
 }

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1,7 +1,7 @@
 /*
- * 
+ *
  * stylesheet web-TLO (Web Torrent List Organizer)
- * 
+ *
  */
 
 /* @import url("./reset.css"); */
@@ -474,6 +474,10 @@ button.settings-button {
     display: inline-block;
     text-align: right;
     width: 8em;
+}
+
+.forum-open-link {
+    cursor: pointer;
 }
 
 #forum_url_params label, #api_url_params label {

--- a/src/index.php
+++ b/src/index.php
@@ -729,6 +729,7 @@ function cfg_checkbox($cfg): Closure
                                            class="myinput" size="25"
                                            placeholder="Логин на форуме" title="Логин на форуме"
                                            value="<?= $cfg['tracker_login'] ?>"/>
+                                    <i class="fa fa-link forum-open-link" title="Открыть ссылку на профиль"></i>
                                 </div>
                                 <div>
                                     <label for="tracker_password" class="param-name">Пароль:</label>
@@ -907,28 +908,29 @@ function cfg_checkbox($cfg): Closure
                                 </label>
                             </div>
                             <fieldset id="forum-props">
-                                <label>
+                                <label title="Индекс подраздела">
                                     Индекс:
-                                    <input disabled size=10 id="forum-id" class="myinput forum-props ui-state-disabled" type="text" title="Индекс подраздела" />
+                                    <input disabled size=10 id="forum-id" class="myinput forum-props ui-state-disabled" type="text" />
+                                    <i class="fa fa-link" title="Открыть ссылку на подраздел"></i>
                                 </label>
-                                <label>
+                                <label title="Добавлять раздачи текущего подраздела в торрент-клиент">
                                     Торрент-клиент:
-                                    <select id="forum-client" class="myinput forum-props" title="Добавлять раздачи текущего подраздела в торрент-клиент">
+                                    <select id="forum-client" class="myinput forum-props">
                                         <option value=0>не выбран</option>
                                         <?= $optionTorrentClients ?? '' ?>
                                     </select>
                                 </label>
-                                <label>
+                                <label title="При добавлении раздачи установить для неё метку (поддерживаются только Deluge, qBittorrent, Flood и uTorrent)">
                                     Метка:
-                                    <input id="forum-label" class="myinput forum-props" type="text" size="50" title="При добавлении раздачи установить для неё метку (поддерживаются только Deluge, qBittorrent, Flood и uTorrent)" />
+                                    <input id="forum-label" class="myinput forum-props" type="text" size="50" />
                                 </label>
-                                <label>
+                                <label title="При добавлении раздачи данные сохранять в каталог">
                                     Каталог для данных:
-                                    <input id="forum-savepath" class="myinput forum-props" type="text" size="57" title="При добавлении раздачи данные сохранять в каталог" />
+                                    <input id="forum-savepath" class="myinput forum-props" type="text" size="57" />
                                 </label>
-                                <label>
+                                <label title="Создавать подкаталог для данных добавляемой раздачи">
                                     Создавать подкаталог для добавляемой раздачи:
-                                    <select id="forum-subdirectory" class="myinput forum-props" title="Создавать подкаталог для данных добавляемой раздачи">
+                                    <select id="forum-subdirectory" class="myinput forum-props">
                                         <option value="0">нет</option>
                                         <option value="1">номер темы</option>
                                         <option value="2">хэш раздачи</option>
@@ -1316,6 +1318,7 @@ function cfg_checkbox($cfg): Closure
 
     <!-- скрипты webtlo -->
     <script type="text/javascript" src="scripts/jquery.common.js"></script>
+    <script type="text/javascript" src="scripts/jquery.settings.func.js"></script>
     <script type="text/javascript" src="scripts/jquery.topics.func.js"></script>
     <script type="text/javascript" src="scripts/jquery.subsections.func.js"></script>
     <script type="text/javascript" src="scripts/jquery.clients.func.js"></script>

--- a/src/scripts/jquery.actions.js
+++ b/src/scripts/jquery.actions.js
@@ -355,22 +355,37 @@ $(document).ready(function () {
     $("#get_reports").on("click", function () {
         getReport();
     })
+
     // получение статистики
-    $("#get_statistics").on("click", function () {
+    $('#get_statistics').on('click', function () {
         $.ajax({
             context: this,
-            type: "POST",
-            url: "php/actions/get_statistics.php",
+            type: 'POST',
+            url: 'php/actions/get_statistics.php',
             beforeSend: function () {
-                $(this).addClass("ui-state-disabled").prop("disabled", true);
+                $(this).toggleDisable(true);
             },
             success: function (response) {
                 response = $.parseJSON(response);
-                $("#table_statistics tbody").html(response.tbody);
-                $("#table_statistics tfoot").html(response.tfoot);
+
+                const tab = $('#table_statistics');
+                tab.find('tbody').html(response.tbody);
+                tab.find('tfoot').html(response.tfoot);
+
+                // Добавляем возможность открывать ссылку на подраздел.
+                tab.find('td:first-child')
+                    .addClass('statistic-forum-id')
+                    .prop('title', 'Открыть ссылку на подраздел')
+                    .click(function(e) {
+                        e.preventDefault();
+
+                        const domain = getForumUrl()
+                        const url = `${domain}/forum/viewforum.php?f=${this.innerText}`;
+                        window.open(url, '_blank');
+                    });
             },
             complete: function () {
-                $(this).removeClass("ui-state-disabled").prop("disabled", false);
+                $(this).toggleDisable(false);
             }
         });
     });

--- a/src/scripts/jquery.common.js
+++ b/src/scripts/jquery.common.js
@@ -370,6 +370,13 @@ function versionCompare(v1, v2, options) {
 
 // https://stackoverflow.com/questions/15958671/disabled-fields-not-picked-up-by-serializearray
 (function ($) {
+    /** Вернуть уникальный набор элементов. */
+    $.uniqueValues = function(array) {
+        return $.grep(array, function(el, index) {
+            return index === $.inArray(el, array);
+        });
+    }
+
     $.fn.serializeAllArray = function () {
         var data = $(this).serializeArray();
         $(":disabled[name]", this).each(function () {

--- a/src/scripts/jquery.settings.func.js
+++ b/src/scripts/jquery.settings.func.js
@@ -1,0 +1,13 @@
+
+/* Функции для вкладки настроек. */
+
+// Собрать ссылку на форум из настроек.
+function getForumUrl() {
+    const scheme = $('#forum_ssl').is(':checked') ? 'https' : 'http';
+    let domain = $('#forum_url').val();
+    if (domain === 'custom') {
+        domain = $('#forum_url_custom').val()
+    }
+
+    return `${scheme}://${domain}`;
+}

--- a/src/scripts/jquery.settings.init.js
+++ b/src/scripts/jquery.settings.init.js
@@ -25,9 +25,7 @@ $(document).ready(function () {
             return;
         }
 
-        const domain = getForumUrl()
-        const url = `${domain}/forum/profile.php?mode=viewprofile&u=${user}`;
-        window.open(url, '_blank');
+        openUserProfile(user);
     });
 
 });

--- a/src/scripts/jquery.settings.init.js
+++ b/src/scripts/jquery.settings.init.js
@@ -11,6 +11,23 @@ $(document).ready(function () {
         } else {
             elems.prop('type', 'text');
         }
-    })
+    });
+
+    // Открыть ссылку на профиль пользователя.
+    $('#tracker_username').next('i').click(function(e) {
+        e.preventDefault();
+
+        let user = $('#user_id').val();
+        if (!user) {
+            user = $('#tracker_username').val();
+        }
+        if (!user) {
+            return;
+        }
+
+        const domain = getForumUrl()
+        const url = `${domain}/forum/profile.php?mode=viewprofile&u=${user}`;
+        window.open(url, '_blank');
+    });
 
 });

--- a/src/scripts/jquery.subsections.init.js
+++ b/src/scripts/jquery.subsections.init.js
@@ -66,158 +66,184 @@ $(document).ready(function () {
     });
 
     // прокрутка подразделов на главной
-    $("#main-subsections-button").on("mousewheel", function (event, delta) {
-        var hidden = $("#main-subsections-menu").attr("aria-hidden");
+    $('#main-subsections-button').on('mousewheel', function (event, delta) {
+        let hidden = $('#main-subsections-menu').attr('aria-hidden');
         if (hidden == "false") {
             return false;
         }
-        var forumID = $("#main-subsections").val();
-        var element = $("#main-subsections [value=" + forumID + "]").parent().attr("id");
-        if (typeof element === "undefined") {
+
+        const mainSubsection = $('#main-subsections');
+        const forumID = mainSubsection.val();
+
+        const element = $(`#main-subsections [value=${forumID}]`).parent().attr("id");
+        if (typeof element === 'undefined') {
             return false;
         }
-        var totalNumberSubsectionsOptions = $("#main-subsections-stored option").size();
-        var totalNumberAdditionalOptions = $("#main-subsections optgroup:first option").size();
-        var indexSelectedOption = $("#main-subsections").prop("selectedIndex");
-        var nextIndexNumber = indexSelectedOption - totalNumberAdditionalOptions - delta;
-        if (nextIndexNumber == totalNumberSubsectionsOptions) {
+
+        const totalNumberSubsectionsOptions = +$("#main-subsections-stored option").size();
+        const totalNumberAdditionalOptions = +$("#main-subsections optgroup:first option").size();
+        const indexSelectedOption = +mainSubsection.prop('selectedIndex');
+
+        let nextIndexNumber = indexSelectedOption - totalNumberAdditionalOptions - delta;
+        if (nextIndexNumber === totalNumberSubsectionsOptions) {
             nextIndexNumber = 0;
         }
-        $("#main-subsections-stored :eq(" + nextIndexNumber + ")").prop("selected", "selected");
-        $("#main-subsections").selectmenu("refresh");
+
+        $(`#main-subsections-stored :eq(${nextIndexNumber})`).prop('selected', 'selected');
+        mainSubsection.selectmenu('refresh');
+
         forumDataShowDelay(getFilteredTopics);
+
         return false;
     });
 
     // получение свойств выбранного подраздела
-    $("#list-forums").on("change selectmenuchange", function () {
-        var forumData = $("#list-forums :selected").data();
-        if (forumData.client == '') {
+    $('#list-forums').on('change selectmenuchange', function () {
+        let forumData = $('#list-forums :selected').data();
+        if (forumData.client === '') {
             forumData.client = 0;
         }
-        if (forumData.subdirectory == '') {
+        if (forumData.subdirectory === '') {
             forumData.subdirectory = 0;
         }
-        if (forumData.hide == '') {
+        if (forumData.hide === '') {
             forumData.hide = 0;
         }
-        if (forumData.exclude == '') {
+        if (forumData.exclude === '') {
             forumData.exclude = 0;
         }
-        var torrentClientID = $("#forum-client option[value=" + forumData.client + "]").val();
-        if (typeof torrentClientID === "undefined") {
-            $("#forum-client :first").prop("selected", "selected");
+
+        const forumClient = $('#forum-client');
+
+        const torrentClientID = $(`#forum-client option[value=${forumData.client}]`).val();
+        if (typeof torrentClientID === 'undefined') {
+            $('#forum-client :first').prop('selected', 'selected');
         } else {
-            $("#forum-client").val(torrentClientID);
+            forumClient.val(torrentClientID);
         }
-        var subdirectory = $("#forum-subdirectory option[value=" + forumData.subdirectory + "]").val();
-        if (typeof subdirectory === "undefined") {
-            $("#forum-subdirectory :first").prop("selected", "selected");
+
+        const useSubDirectory = $(`#forum-subdirectory option[value=${forumData.subdirectory}]`).val();
+        if (typeof useSubDirectory === 'undefined') {
+            $('#forum-subdirectory :first').prop('selected', 'selected');
         } else {
-            $("#forum-subdirectory [value=" + subdirectory + "]").prop("selected", "selected");
+            $(`#forum-subdirectory [value=${useSubDirectory}]`).prop('selected', 'selected');
         }
-        var hideTopics = $("#forum-hide-topics [value=" + forumData.hide + "]").val();
+
+        const hideTopics = $(`#forum-hide-topics [value=${forumData.hide}]`).val();
         if (typeof hideTopics === "undefined") {
-            $("#forum-hide-topics :first").prop("selected", "selected");
+            $("#forum-hide-topics :first").prop('selected', 'selected');
         } else {
-            $("#forum-hide-topics [value=" + hideTopics + "]").prop("selected", "selected");
+            $(`#forum-hide-topics [value=${hideTopics}]`).prop('selected', 'selected');
         }
-        var forumExclude = $("#forum-exclude [value=" + forumData.exclude + "]").val();
-        if (typeof forumExclude === "undefined") {
-            $("#forum-exclude :first").prop("selected", "selected");
+
+        const forumExclude = $(`#forum-exclude [value=${forumData.exclude}]`).val();
+        if (typeof forumExclude === 'undefined') {
+            $('#forum-exclude :first').prop('selected', 'selected');
         } else {
-            $("#forum-exclude [value=" + forumExclude + "]").prop("selected", "selected");
+            $(`#forum-exclude [value=${forumExclude}]`).prop('selected', 'selected');
         }
-        $("#forum-label").val(forumData.label);
-        $("#forum-savepath").val(forumData.savepath);
-        $("#forum-control-peers").val(forumData.peers);
+
         editableForumID = $(this).val();
-        $("#forum-id").val(editableForumID);
-        $("#forum-client").selectmenu().selectmenu("refresh");
-        $("#forum-subdirectory").selectmenu().selectmenu("refresh");
-        $("#forum-hide-topics").selectmenu().selectmenu("refresh");
-        $("#forum-exclude").selectmenu().selectmenu("refresh");
+        $('#forum-id').val(editableForumID);
+
+        $('#forum-label').val(forumData.label);
+        $('#forum-savepath').val(forumData.savepath);
+        $('#forum-control-peers').val(forumData.peers);
+
+        forumClient.selectmenu().selectmenu('refresh');
+        $('#forum-subdirectory').selectmenu().selectmenu('refresh');
+        $('#forum-hide-topics').selectmenu().selectmenu('refresh');
+        $('#forum-exclude').selectmenu().selectmenu('refresh');
     });
 
     // изменение свойств подраздела
-    $("#forum-props").on("focusout selectmenuchange spinstop", function () {
-        var forumClient = $("#forum-client :selected").val();
-        var forumLabel = $("#forum-label").val();
-        var forumSavePath = $("#forum-savepath").val();
-        var forumSubdirectory = $("#forum-subdirectory").val();
-        var forumHideTopics = $("#forum-hide-topics :selected").val();
-        var forumControlPeers = $("#forum-control-peers").val();
-        var forumExclude = $("#forum-exclude :selected").val();
-        var optionForum = $("#list-forums option[value=" + editableForumID + "]");
-        optionForum.attr("data-client", forumClient).data("client", forumClient);
-        optionForum.attr("data-label", forumLabel).data("label", forumLabel);
-        optionForum.attr("data-savepath", forumSavePath).data("savepath", forumSavePath);
-        optionForum.attr("data-subdirectory", forumSubdirectory).data("subdirectory", forumSubdirectory);
-        optionForum.attr("data-hide", forumHideTopics).data("hide", forumHideTopics);
-        optionForum.attr("data-peers", forumControlPeers).data("peers", forumControlPeers);
-        optionForum.attr("data-exclude", forumExclude).data("exclude", forumExclude);
+    $('#forum-props').on('focusout selectmenuchange spinstop', function () {
+        const forumClient = $("#forum-client :selected").val();
+        const forumLabel = $("#forum-label").val();
+        const forumSavePath = $("#forum-savepath").val();
+        const forumSubdirectory = $("#forum-subdirectory").val();
+        const forumHideTopics = $("#forum-hide-topics :selected").val();
+        const forumControlPeers = $("#forum-control-peers").val();
+        const forumExclude = $("#forum-exclude :selected").val();
+        const optionForum = $(`#list-forums option[value=${editableForumID}]`);
+
+        optionForum.attr('data-client', forumClient).data('client', forumClient);
+        optionForum.attr('data-label', forumLabel).data('label', forumLabel);
+        optionForum.attr('data-save path', forumSavePath).data("save path", forumSavePath);
+        optionForum.attr('data-subdirectory', forumSubdirectory).data('subdirectory', forumSubdirectory);
+        optionForum.attr('data-hide', forumHideTopics).data('hide', forumHideTopics);
+        optionForum.attr('data-peers', forumControlPeers).data('peers', forumControlPeers);
+        optionForum.attr('data-exclude', forumExclude).data('exclude', forumExclude);
 
         refreshExcludedSubsections();
     });
 
     // добавить подраздел
-    $("#add-forum").autocomplete({
-        source: "php/actions/get_list_subsections.php",
-        delay: 1000,
+    $('#add-forum').autocomplete({
+        source   : 'php/actions/get_list_subsections.php',
+        delay    : 1000,
         minLength: 3,
-        select: addSubsection,
-        search: function (event, ui) {
-            var color = $(".ui-widget-content").css("color");
-            $(".spinner").css("border-color", color + " " + color + " transparent transparent");
-            $(this).closest("div").find("div").show();
+        select   : addSubsection,
+        search   : function(event, ui) {
+            const color = $('.ui-widget-content').css('color');
+
+            $('.spinner').css('border-color', `${color} ${color} transparent transparent`);
+            $(this).closest('div').find('div').show();
         },
-        response: function (event, ui) {
-            $(this).closest("div").find("div").hide();
+        response : function(event, ui) {
+            $(this).closest('div').find('div').hide();
             if ((ui.content.length) === 0) {
-                $(this).addClass("ui-state-error");
+                $(this).addClass('ui-state-error');
             }
             if ((ui.content.length) === 1) {
-                $(this).data('ui-autocomplete')._trigger('select', 'autocompleteselect', { item: ui.content[0] });
-                $("#list-forums-button").addClass("ui-state-highlight");
-                $(this).val("").autocomplete("close");
+                $(this).data('ui-autocomplete')._trigger('select', 'autocompleteselect', {item: ui.content[0]});
+                $('#list-forums-button').addClass('ui-state-highlight');
+                $(this).val('').autocomplete('close');
             }
         },
-    }).on("input", function(){
-        $(this).removeClass("ui-state-error");
-        $("#list-forums-button").removeClass("ui-state-highlight");
+    }).on('input', function(){
+        $(this).removeClass('ui-state-error');
+        $('#list-forums-button').removeClass('ui-state-highlight');
     });
 
     // удалить подраздел
-    $("#remove-forum").on("click", function () {
-        var forumID = $("#list-forums").val();
+    $('#remove-forum').on('click', function () {
+        const forumList = $('#list-forums');
+        const forumID = forumList.val();
         if (typeof forumID === "undefined") {
             return false;
         }
-        var optionIndex = $("#list-forums :selected").index();
-        $("#list-forums :selected").remove();
-        $("#main-subsections-stored [value=" + forumID + "]").remove();
-        $("#reports-subsections-stored [value=" + forumID + "]").remove();
-        var optionTotal = $("select[id=list-forums] option").size();
-        if (optionTotal == 0) {
-            $(".forum-props, #list-forums").val("").addClass("ui-state-disabled").prop("disabled", true);
-            $("#forum-client :first").prop("selected", "selected");
+
+        const selectedForum = $('#list-forums :selected');
+        let optionIndex = selectedForum.index();
+        selectedForum.remove();
+
+        $(`#main-subsections-stored [value=${forumID}]`).remove();
+        $(`#reports-subsections-stored [value=${forumID}]`).remove();
+
+        const optionTotal = $('select[id=list-forums] option').size();
+        if (optionTotal === 0) {
+            $('.forum-props, #list-forums').val('').addClass('ui-state-disabled').prop('disabled', true);
+            $("#forum-client :first").prop('selected', 'selected');
         } else {
-            if (optionTotal != optionIndex) {
+            if (optionTotal !== optionIndex) {
                 optionIndex++;
             }
-            $("#list-forums :nth-child(" + optionIndex + ")").prop("selected", "selected").change();
+            $(`#list-forums :nth-child(${optionIndex})`).prop('selected', 'selected').change();
         }
-        $("#main-subsections").selectmenu("refresh");
-        $("#reports-subsections").selectmenu("refresh");
-        $("#list-forums").selectmenu("refresh");
+
+        $('#main-subsections').selectmenu('refresh');
+        $('#reports-subsections').selectmenu('refresh');
+        forumList.selectmenu('refresh');
+
         getFilteredTopics();
     });
 
     // при загрузке выбрать первый подраздел в списке
-    if ($("select[id=list-forums] option").size() > 0) {
-        $("#list-forums :first").prop("selected", "selected").change();
+    if ($('select[id=list-forums] option').size() > 0) {
+        $('#list-forums :first').prop('selected', 'selected').change();
     } else {
-        $(".forum-props").addClass("ui-state-disabled").prop("disabled", true);
+        $('.forum-props').addClass('ui-state-disabled').prop('disabled', true);
     }
 
 });

--- a/src/scripts/jquery.subsections.init.js
+++ b/src/scripts/jquery.subsections.init.js
@@ -246,4 +246,17 @@ $(document).ready(function () {
         $('.forum-props').addClass('ui-state-disabled').prop('disabled', true);
     }
 
+    // Открыть ссылку на подраздел.
+    $('#forum-id').next('i').click(function(e) {
+        e.preventDefault();
+
+        if (!editableForumID) {
+            return;
+        }
+
+        const domain = getForumUrl()
+        const url = `${domain}/forum/viewforum.php?f=${editableForumID}`;
+        window.open(url, '_blank');
+    });
+
 });

--- a/src/scripts/jquery.topics.func.js
+++ b/src/scripts/jquery.topics.func.js
@@ -351,6 +351,21 @@ function loadSavedFilterOptions(filter_options) {
     $('.filter_status_controlgroup').controlgroup('refresh');
 }
 
+/**
+ * Открыть профиль пользователя.
+ *
+ * @param {number|string} user id/name
+ */
+function openUserProfile(user) {
+    if (!user) {
+        return;
+    }
+
+    const domain = getForumUrl()
+    const url = `${domain}/forum/profile.php?mode=viewprofile&u=${user}`;
+    window.open(url, '_blank');
+}
+
 /** Проверка наличия раздач без названия + отображение. */
 let refreshTopics = {
     interval: null,

--- a/src/scripts/jquery.topics.init.js
+++ b/src/scripts/jquery.topics.init.js
@@ -3,6 +3,8 @@
 
 $(document).ready(function () {
 
+    const topicsForm = $('#topics');
+
     $(".tor_download").on("click", function () {
         downloadTorrents($(this).val());
     });
@@ -285,30 +287,41 @@ $(document).ready(function () {
         }
     });
 
+    topicsForm.on('mousedown', '.keeper', function (e) {
+        if (e.altKey || e.which === 2) {
+            e.preventDefault();
+            openUserProfile($(this).text());
+        }
+    });
+
     // ник хранителя в поиск при двойном клике
-    $("#topics").on("dblclick", ".keeper", function (e) {
-        var searchLine = "";
-        var searchBox = $("input[name=filter_phrase]");
+    topicsForm.on('dblclick', '.keeper', function (e) {
+        const keeperName = $(this).text();
+        const searchBox = $('input[name=filter_phrase]');
+        const prevSearch = searchBox.val();
+
+        // Собираем желаемый список поисковых значений.
+        let values = prevSearch ? prevSearch.split(',') : [];
         if (e.ctrlKey) {
-            searchLine = searchBox.val() + "," + $(this).text();
-            searchBox.val(searchLine);
+            values.push(keeperName);
         } else {
-            searchLine = $(this).text();
-            searchBox.val(searchLine);
+            values = [keeperName];
         }
+
+        // Убираем повторы.
+        const newSearch = $.uniqueValues(values).join(',');
+        if (newSearch === prevSearch) {
+            return;
+        }
+
+        // Применяем поиск.
+        searchBox.val(newSearch);
+
         selectBlockText(this);
-        $('input[name=filter_by_phrase][type="radio"]').prop("checked", false);
-        $('#filter_by_keeper').prop("checked", true);
-        var isKeepers = $('input[name=is_keepers][type="checkbox"]').prop("checked");
-        var isKeepersSeeders = $('input[name=is_keepers_seeders][type="checkbox"]').prop("checked");
-        if (
-            !isKeepers
-            && !isKeepersSeeders
-        ) {
-            $('input[name=not_keepers_seeders][type="checkbox"]').prop("checked", false);
-            $('input[name=not_keepers][type="checkbox"]').prop("checked", false).change();
-        }
-        $("#topics_filter").trigger("change");
+        $('input[name=filter_by_phrase][type="radio"]').prop('checked', false);
+        $('#filter_by_keeper').prop('checked', true);
+
+        $('#topics_filter').trigger('change');
     });
 
     // клиент в поиск при двойном клике


### PR DESCRIPTION
close #332, close #333 


Добавлена ссылка на выбранный хранимый подраздел.
![image](https://github.com/keepers-team/webtlo/assets/54838254/b62f8dc2-2a18-4746-90d4-9a53a018e876)

Добавлены ссылки на хранимые подразделы.
![image](https://github.com/keepers-team/webtlo/assets/54838254/9a252abe-1a83-4a33-814a-42851130d326)


Добавлена ссылка на свой профиль.
![image](https://github.com/keepers-team/webtlo/assets/54838254/e163278d-594c-4c3d-b539-37c50f60d299)



Добавлена возможность открыть профиль хранителя из списка раздач.
`Alt+click` или `middle-click` (колёсико).
Дабл клик заменяет строку поиска по хранителю на выбранного.
Ctrl + даблклик - добавляет хранителя в список поиска.
