### PR TITLE
Улучшение работы с торрентами

### DIFF
--- a/src/back/AppContainer.php
+++ b/src/back/AppContainer.php
@@ -10,6 +10,7 @@ use KeepersTeam\Webtlo\Config\Credentials;
 use KeepersTeam\Webtlo\Config\ForumCredentials;
 use KeepersTeam\Webtlo\Config\Proxy;
 use KeepersTeam\Webtlo\Config\ReportSend;
+use KeepersTeam\Webtlo\Config\TopicControl;
 use KeepersTeam\Webtlo\External\ApiClient;
 use KeepersTeam\Webtlo\External\ApiReportClient;
 use KeepersTeam\Webtlo\External\ForumClient;
@@ -66,6 +67,9 @@ final class AppContainer
 
         // Опции получения и отправки отчётов.
         $container->add(ReportSend::class, fn() => ReportSend::getReportSend($container->get('config')));
+
+        // Опции регулировки раздач.
+        $container->add(TopicControl::class, fn() => TopicControl::getTopicControl($container->get('config')));
 
         // Получаем настройки прокси.
         $container->add(Proxy::class, fn() => Proxy::fromLegacy($container->get('config')));

--- a/src/back/Clients/ClientInterface.php
+++ b/src/back/Clients/ClientInterface.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace KeepersTeam\Webtlo\Clients;
 
+use KeepersTeam\Webtlo\Clients\Data\Torrent;
+use KeepersTeam\Webtlo\Clients\Data\Torrents;
+
 /**
  * Набор функциональных возможностей торрент-клиента.
  */
@@ -18,9 +21,9 @@ interface ClientInterface
      * Получение сведений о раздачах от торрент-клиента
      *
      * @param array<string, mixed> $filter
-     * @return array<string, array<string, mixed>>
+     * @return Torrents
      */
-    public function getTorrents(array $filter = []): array;
+    public function getTorrents(array $filter = []): Torrents;
 
     /**
      * Добавить раздачу в торрент-клиент из файла.

--- a/src/back/Clients/Data/Torrent.php
+++ b/src/back/Clients/Data/Torrent.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KeepersTeam\Webtlo\Clients\Data;
+
+use DateTimeImmutable;
+
+/**
+ * Данные одной раздачи в торрент клиенте.
+ */
+final class Torrent
+{
+    /**
+     * @param string            $topicHash    Хеш раздачи на форуме.
+     * @param string            $clientHash   Хеш раздачи в клиенте.
+     * @param string            $name         Название раздачи.
+     * @param int|null          $topicId      Ид темы на форуме.
+     * @param int               $size         Размер раздачи.
+     * @param DateTimeImmutable $added        Дата добавления раздачи в клиенте.
+     * @param int|float         $done         Прогресс загрузки (1 = скачана, <1 - качается).
+     * @param bool              $paused       Остановлена ли раздача в клиенте.
+     * @param bool              $error        Есть ошибка в клиенте.
+     * @param string|null       $trackerError Текст ошибки трекера.
+     * @param string|null       $comment      Текст комментария раздачи (содержит topicId).
+     * @param string|null       $storagePath  Путь хранения раздачи на диске.
+     */
+    public function __construct(
+        public readonly string            $topicHash,
+        public readonly string            $clientHash,
+        public readonly string            $name,
+        public readonly ?int              $topicId,
+        public readonly int               $size,
+        public readonly DateTimeImmutable $added,
+        public readonly int|float         $done,
+        public readonly bool              $paused,
+        public readonly bool              $error = false,
+        public readonly ?string           $trackerError = null,
+        public readonly ?string           $comment = null,
+        public readonly ?string           $storagePath = null,
+    ) {
+    }
+}

--- a/src/back/Clients/Data/Torrents.php
+++ b/src/back/Clients/Data/Torrents.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KeepersTeam\Webtlo\Clients\Data;
+
+use Countable;
+use Generator;
+
+/**
+ * Набор раздач из одного торрент-клиента.
+ */
+final class Torrents implements Countable
+{
+    /**
+     * @param array<string, Torrent> $torrents
+     */
+    public function __construct(public readonly array $torrents = [])
+    {
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getHashes(): array
+    {
+        return array_map('strval', array_keys($this->torrents));
+    }
+
+    public function getTorrent(string $hash): ?Torrent
+    {
+        return $this->torrents[strtoupper($hash)] ?? null;
+    }
+
+    public function getGenerator(): Generator
+    {
+        foreach ($this->torrents as $hash => $torrent) {
+            yield $hash => $torrent;
+        }
+    }
+
+    // Countable
+
+    public function count(): int
+    {
+        return count($this->torrents);
+    }
+
+    public function empty(): bool
+    {
+        return $this->torrents === [];
+    }
+}

--- a/src/back/Clients/Traits/TopicIdSearch.php
+++ b/src/back/Clients/Traits/TopicIdSearch.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KeepersTeam\Webtlo\Clients\Traits;
+
+use KeepersTeam\Webtlo\Module\Topics;
+use KeepersTeam\Webtlo\Module\Torrents;
+use KeepersTeam\Webtlo\Timers;
+
+trait TopicIdSearch
+{
+    /**
+     * @param array<string, mixed> $torrents
+     * @return array{}|array<string, mixed>
+     */
+    protected static function getEmptyTopics(array $torrents): array
+    {
+        return array_filter($torrents, fn($el) => empty($el['topic_id']));
+    }
+
+    /**
+     * @param array<string, mixed> $torrents
+     * @return array{}|string[]
+     */
+    protected static function getEmptyTopicsHashes(array $torrents): array
+    {
+        $emptyTopics = self::getEmptyTopics($torrents);
+
+        return array_map('strval', array_keys($emptyTopics));
+    }
+
+    /**
+     * Пробуем найти раздачи в локальной таблице раздач хранимых подразделов.
+     *
+     * @param array<string, mixed> $torrents
+     */
+    protected function tryFillTopicIdFromTopics(array &$torrents): void
+    {
+        Timers::start('db_topics_search');
+
+        $emptyHashed = self::getEmptyTopicsHashes($torrents);
+        if (count($emptyHashed)) {
+            $this->logger->debug('Start search torrents in Topics table', ['empty' => count($emptyHashed)]);
+
+            $topics = Topics::getTopicsIdsByHashes($emptyHashed);
+            if (count($topics)) {
+                $torrents = array_replace_recursive($torrents, $topics);
+            }
+
+            Timers::stash('db_topics_search');
+            $this->logger->debug('End search torrents in Topics table', ['filled' => count($topics)]);
+        }
+    }
+
+    /**
+     * Пробуем найти раздачи в локальной таблице раздач в клиентах.
+     *
+     * @param array<string, mixed> $torrents
+     */
+    protected function tryFillTopicIdFromTorrents(array &$torrents): void
+    {
+        Timers::start('db_torrents_search');
+
+        $emptyHashed = self::getEmptyTopicsHashes($torrents);
+        if (count($emptyHashed)) {
+            $this->logger->debug('Start search torrents in Torrents table', ['empty' => count($emptyHashed)]);
+
+            $topics = Torrents::getTopicsIdsByHashes($emptyHashed);
+            if (count($topics)) {
+                $torrents = array_replace_recursive($torrents, $topics);
+            }
+
+            Timers::stash('db_torrents_search');
+            $this->logger->debug('End search torrents in Torrents table', ['filled' => count($topics)]);
+        }
+    }
+}

--- a/src/back/Config/TopicControl.php
+++ b/src/back/Config/TopicControl.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KeepersTeam\Webtlo\Config;
+
+/**
+ * Параметры для регулировки (запуска/остановки) раздач в торрент-клиентах.
+ */
+final class TopicControl
+{
+    /**
+     * Сид - пользователь, сидирующий раздачу.
+     * Лич - пользователь, который либо качает раздачу, либо скачал только часть раздачи.
+     * Сид-хранитель - это сид, из числа хранителей, который в данный момент сидирует раздачу.
+     *
+     * Сиды-хранители ⊆ Сиды
+     */
+
+    /**
+     * @param int  $peersLimit             Предел пиров при регулировке
+     * @param int  $excludedKeepersCount   Количество исключаемых из регулировки хранителей на раздаче
+     * @param bool $countLeechersAsPeers   Учитывать личей при подсчёте пиров
+     * @param bool $seedingWithoutLeechers Сидировать раздачи, на которых нет личей
+     * @param bool $manageOtherSubsections Регулировать раздачи из прочих подразделов
+     */
+    public function __construct(
+        public readonly int  $peersLimit,
+        public readonly int  $excludedKeepersCount,
+        public readonly bool $countLeechersAsPeers,
+        public readonly bool $seedingWithoutLeechers,
+        public readonly bool $manageOtherSubsections,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $cfg
+     */
+    public static function getTopicControl(array $cfg): TopicControl
+    {
+        $control = $cfg['topics_control'] ?? [];
+
+        return new TopicControl(
+            peersLimit            : (int)($control['peers'] ?? 10),
+            excludedKeepersCount  : (int)($control['keepers'] ?? 3),
+            countLeechersAsPeers  : (bool)($control['leechers'] ?? 0),
+            seedingWithoutLeechers: (bool)($control['no_leechers'] ?? 1),
+            manageOtherSubsections: (bool)($control['unadded_subsections'] ?? 0),
+        );
+    }
+}


### PR DESCRIPTION
Close #370 #371

- Добавлено DTO Torrent и Torrents для хранения данных о раздачах в торрент клиентах
- Для поддерживаемых клиентов добавлен алгоритм получения более реалистичного процента скачивания, в случаях, когда выбраны не все файлы 
```
deluge 2.1.1 - можно проверить процент по каждому файлу, и прикинуть общий реальный процент выбранного и скачанного;
flood - поверх qbit, rtorrent, trans, etc, данных о реальном проценте выбранного и скачанного я не нашёл;
qbit 4.5 - есть тег availability, который если не равен -1 представляет собой тот самый процент;
rtorrent хз какой - есть количество "байт осталось". Если выбрана часть раздачи, то там всегда будет какое-то значение. Можно посчитать реальный процент раздачи;
trans 3.0 - просто использовать percentComplete вместо percentDone
utorrent 1.8.2 - ну, тут вообще ничего нет. Есть AVAILABILITY (integer in 1/65536ths), которое может быть >65536. Видимо это "общая" доступность данных среди всех видимых пиров.
```
- Упрощены алгоритмы работы с клиентами, и уменьшено потребление памяти при обработке данных
- Скорректированы алгоритмы использующие списки раздач из клиентов (`control.php`, `tor_clients.php`)