### PR TITLE
Debug messages to trace the error "No reports found for given user"

### DIFF
--- a/src/back/External/Forum/SummaryReport.php
+++ b/src/back/External/Forum/SummaryReport.php
@@ -62,7 +62,7 @@ trait SummaryReport
      *
      * @return ?int Идентификатор сообщения, если найден, иначе null
      */
-    private static function parsePostIdFromReportSearch(string $page): ?int
+    private function parsePostIdFromReportSearch(string $page): ?int
     {
         $dom = self::parseDOM(page: $page);
 
@@ -86,8 +86,11 @@ trait SummaryReport
             if (2 === count($matches)) {
                 return (int) $matches[1];
             }
+            $this->logger->debug('parsePostIdFromReportSearch', ['$postLink' => $postLink]);
+
         }
 
+        $this->logger->debug('parsePostIdFromReportSearch', ['$xpathQuery' => $xpathQuery, 'nodes' => $nodes]);
         return null;
     }
 }

--- a/src/back/External/Forum/SummaryReport.php
+++ b/src/back/External/Forum/SummaryReport.php
@@ -86,11 +86,12 @@ trait SummaryReport
             if (2 === count($matches)) {
                 return (int) $matches[1];
             }
-            $this->logger->debug('parsePostIdFromReportSearch', ['$postLink' => $postLink]);
 
+            $this->logger->debug('parsePostIdFromReportSearch', ['postLink' => $postLink, 'matches' => $matches]);
         }
 
-        $this->logger->debug('parsePostIdFromReportSearch', ['$xpathQuery' => $xpathQuery, 'nodes' => $nodes]);
+        $this->logger->debug('parsePostIdFromReportSearch', ['xpathQuery' => $xpathQuery, 'nodes' => $nodes]);
+
         return null;
     }
 }


### PR DESCRIPTION
Added debug messages to trace the error "No reports found for given user" when the log level is "Debug". 

The parsePostIdFromReportSearch method will call the logger, therefore, it will no longer be static.