### PR TITLE
Unset kept status for forum without kept topics on report send

### DIFF
--- a/src/back/Module/Report/CreateReport.php
+++ b/src/back/Module/Report/CreateReport.php
@@ -591,10 +591,10 @@ final class CreateReport
      *
      * @return array<string, mixed>[]
      */
-    public function getStoredForumTopics(int $forum_id): array
+    public function getStoredForumTopics(int $forumId): array
     {
-        if (!empty($this->cache[$forum_id])) {
-            return $this->cache[$forum_id];
+        if (!empty($this->cache[$forumId])) {
+            return $this->cache[$forumId];
         }
 
         // Получение данных о раздачах подраздела.
@@ -616,14 +616,14 @@ final class CreateReport
                 GROUP BY tp.id, tp.info_hash, tp.forum_id, tp.name, tp.size, tp.status
                 ORDER BY tp.id
             ",
-            array_merge([$forum_id], $excludeClients->values),
+            array_merge([$forumId], $excludeClients->values),
         );
 
-        if (empty($topics)) {
-            throw new RuntimeException("Не получены данные о хранимых раздачах для подраздела № $forum_id");
+        if (!count($topics)) {
+            throw new EmptyFoundTopicsException('В БД не найдены хранимые раздачи подраздела.', $forumId);
         }
 
-        $this->cache[$forum_id] = $topics;
+        $this->cache[$forumId] = $topics;
 
         return $topics;
     }

--- a/src/back/Module/Report/EmptyFoundTopicsException.php
+++ b/src/back/Module/Report/EmptyFoundTopicsException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KeepersTeam\Webtlo\Module\Report;
+
+use RuntimeException;
+
+/**
+ * Нет хранимых раздач в заданном подразделе.
+ */
+final class EmptyFoundTopicsException extends RuntimeException {}


### PR DESCRIPTION
Если подраздел заявлен как хранимый (добавлен в список подразделов в настройках), но нет фактически хранимых раздач из этого подраздела, то теперь отметка "хранения" будет сниматься с такого подраздела и всех его раздач в API, при отправке отчётов.

Данное поведение исправит ситуацию, когда хранитель удалил все хранимые раздачи, но не удалил подраздел из настроек и всё равно считался хранителем уже удалённых раздач.