### PR TITLE
When the same torrent was in different clients, the output countained duplicate lines

### DIFF
--- a/src/php/actions/get_recovery_list.php
+++ b/src/php/actions/get_recovery_list.php
@@ -91,6 +91,7 @@ try {
     ksort($output, SORT_NATURAL);
 
     foreach ($output as $categoryName => $categoryData) {
+        $categoryData = array_unique($categoryData);
         asort($categoryData, SORT_NATURAL);
 
         echo '[b]' . $categoryName . '[/b][hr]</br>';


### PR DESCRIPTION
When the same torrent was in different clients, the output list contained duplicate entries, i.e. the same torrent was listed multiple times, which is not needed for the report of recovery list.