### PR TITLE
The output list contained duplicate entires

### DIFF
--- a/src/php/actions/get_recovery_list.php
+++ b/src/php/actions/get_recovery_list.php
@@ -47,7 +47,7 @@ try {
     $in = str_repeat('?,', count($allowedStatuses) - 1) . '?';
 
     $topics = $db->query(
-        'SELECT
+        'SELECT DISTINCT
             tr.topic_id,
             tu.status,
             tu.transferred_from,


### PR DESCRIPTION
When the same torrent was in different clients, the output list contained duplicate entries, i.e. the same torrent was listed multiple times, which is not needed for the report of recovery list