### PR TITLE
Обновление правил php-cs-fixer для версии 3.70+

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -31,6 +31,8 @@ $rules = [
     'blank_line_before_statement' => true,
     'type_declaration_spaces'     => false,
 
+    'operator_linebreak' => ['only_booleans' => true],
+
     'binary_operator_spaces' => [
         'default'   => 'at_least_single_space',
         'operators' => ['=' => 'align'],

--- a/src/back/Module/Report/CreateReport.php
+++ b/src/back/Module/Report/CreateReport.php
@@ -337,9 +337,9 @@ final class CreateReport
             $topicId = $this->getReportTopicId(forum: $forum);
 
             // Ссылка на тему с отчётами подраздела.
-            $leftPart = $topicId !== null ?
-                sprintf($urlPattern, 't', $topicId, $forum->name) :
-                sprintf('[b]%s[/b]', $forum->name);
+            $leftPart = $topicId !== null
+                ? sprintf($urlPattern, 't', $topicId, $forum->name)
+                : sprintf('[b]%s[/b]', $forum->name);
 
             // Ссылка на свой пост(отчёт) и количество + объём раздач.
             $rightPart = sprintf('%s шт. (%s)', $forumValues['keep_count'], $this->bytes($forumValues['keep_size']));
@@ -676,9 +676,9 @@ final class CreateReport
                 $update->addLogRecord($this->logger);
 
                 throw new RuntimeException(
-                    'Сформировать отчёт невозможно. ' .
-                    'Данные в локальной БД неполные. ' .
-                    'Выполните полное обновление данных и попробуйте снова.'
+                    'Сформировать отчёт невозможно. '
+                    . 'Данные в локальной БД неполные. '
+                    . 'Выполните полное обновление данных и попробуйте снова.'
                 );
             }
 

--- a/src/back/TopicList/Validate.php
+++ b/src/back/TopicList/Validate.php
@@ -223,8 +223,7 @@ final class Validate
             $sum_se = implode('+', $temp['sum_se']);
 
             $fields[] = "$qt AS days_seed";
-            $fields[] =
-                "CASE WHEN $qt IS 0 THEN (seeders * 1.) / seeders_updates_today ELSE ( seeders * 1. + $sum_se) / ( seeders_updates_today + $sum_qt) END AS seed";
+            $fields[] = "CASE WHEN $qt IS 0 THEN (seeders * 1.) / seeders_updates_today ELSE ( seeders * 1. + $sum_se) / ( seeders_updates_today + $sum_qt) END AS seed";
 
             $joins[] = 'LEFT JOIN Seeders ON Topics.id = Seeders.id';
         } else {


### PR DESCRIPTION
Для версий 3.70+ было изменено поведение правила `operator_linebreak`, см. [release 3.70](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/tag/v3.70.0), [PR 8417](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/8417)

Поправил правила и некоторые файлы.