### PR TITLE
Implemented API rate limiting

### DIFF
--- a/src/back/App.php
+++ b/src/back/App.php
@@ -112,7 +112,8 @@ final class App
             return new ApiClient(
                 ApiClient::getDefaultParams($config),
                 ApiClient::apiClientFromLegacy($config, $logger, $proxy),
-                $logger
+                $logger,
+                $config['api_request_threshold'],
             );
         });
 

--- a/src/back/External/Api/StaticHelper.php
+++ b/src/back/External/Api/StaticHelper.php
@@ -20,7 +20,7 @@ trait StaticHelper
         string          $baseUrl,
         bool            $ssl,
         ?Proxy          $proxy,
-        Timeout         $timeout = new Timeout(),
+        Timeout         $timeout,
     ): Client {
         $clientHeaders = [
             'User-Agent' => Defaults::userAgent,

--- a/src/back/External/ApiClient.php
+++ b/src/back/External/ApiClient.php
@@ -30,6 +30,7 @@ final class ApiClient
     public function __construct(
         private readonly array           $defaultParams,
         private readonly Client          $client,
-        private readonly LoggerInterface $logger
+        private readonly LoggerInterface $logger,
+        private readonly float           $minRequestThreshold,
     ) {}
 }

--- a/src/back/Settings.php
+++ b/src/back/Settings.php
@@ -184,9 +184,10 @@ final class Settings
         $config['forum_connect_timeout'] = $ini->read('curl_setopt', 'forum_connecttimeout', 40);
 
         // Апи для получения сведений о раздачах
-        $config['api_url']        = basename($ini->read('torrent-tracker', 'api_url', 'api.rutracker.cc'));
-        $config['api_url_custom'] = basename($ini->read('torrent-tracker', 'api_url_custom'));
-        $config['api_ssl']        = $ini->read('torrent-tracker', 'api_ssl', 1);
+        $config['api_url']               = basename($ini->read('torrent-tracker', 'api_url', 'api.rutracker.cc'));
+        $config['api_url_custom']        = basename($ini->read('torrent-tracker', 'api_url_custom'));
+        $config['api_ssl']               = $ini->read('torrent-tracker', 'api_ssl', 1);
+        $config['api_request_threshold'] = $ini->read('torrent-tracker', 'api_request_threshold', 0.5);
 
         $config['api_base_url'] = $config['api_url'] === 'custom'
             ? $config['api_url_custom']

--- a/src/back/Update/HighPriority.php
+++ b/src/back/Update/HighPriority.php
@@ -9,6 +9,7 @@ use KeepersTeam\Webtlo\Enum\UpdateMark;
 use KeepersTeam\Webtlo\External\Api\V1\ApiError;
 use KeepersTeam\Webtlo\External\Api\V1\HighPriorityTopic;
 use KeepersTeam\Webtlo\External\Api\V1\KeepingPriority;
+use KeepersTeam\Webtlo\External\Api\V1\TopicSearchMode;
 use KeepersTeam\Webtlo\External\ApiClient;
 use KeepersTeam\Webtlo\Helper;
 use KeepersTeam\Webtlo\Settings;
@@ -123,6 +124,8 @@ final class HighPriority
      */
     private function processSubsectionTopics(array $topics, callable $avgProcessor): void
     {
+        $config = $this->settings->get();
+
         $topics = $this->chunkTopics($topics);
 
         // Перебираем группы раздач.
@@ -195,8 +198,12 @@ final class HighPriority
 
             // Поиск нужных данных о новых раздачах.
             if (count($topicsInsert)) {
-                // Получить описание новых раздач.
-                $response = $this->apiClient->getTopicsDetails(array_keys($topicsInsert));
+                $this->logger->notice(
+                    'Получаем дополнительные сведения для новых раздач ({count} шт.) через API...',
+                    ['count' => count($topicsInsert)]
+                );
+
+                $response = $this->apiClient->getTopicsDetails(array_keys($topicsInsert), TopicSearchMode::ID);
                 if ($response instanceof ApiError) {
                     $this->logger->error(sprintf('%d %s', $response->code, $response->text));
 

--- a/src/back/Update/TopicsDetails.php
+++ b/src/back/Update/TopicsDetails.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace KeepersTeam\Webtlo\Update;
 
 use KeepersTeam\Webtlo\External\Api\V1\ApiError;
+use KeepersTeam\Webtlo\External\Api\V1\TopicSearchMode;
 use KeepersTeam\Webtlo\External\ApiClient;
 use KeepersTeam\Webtlo\Storage\CloneFactory;
 use KeepersTeam\Webtlo\Storage\Table\Topics;
@@ -65,6 +66,10 @@ final class TopicsDetails
 
             $topics = $this->topics->getUnnamedTopics($perRun);
             if (count($topics)) {
+                $this->logger->debug(
+                    'Запрашиваем сведения о раздачах ({count} шт.) через API (запрос {run}/{runs})...',
+                    ['count' => count($topics), 'run' => $run, 'runs' => $runs]
+                );
                 $details = $this->getDetails($topics);
                 if (count($details)) {
                     $tab->cloneFillChunk(dataSet: $details);
@@ -91,7 +96,7 @@ final class TopicsDetails
      */
     private function getDetails(array $topics): array
     {
-        $response = $this->apiClient->getTopicsDetails($topics);
+        $response = $this->apiClient->getTopicsDetails($topics, TopicSearchMode::ID);
         if ($response instanceof ApiError) {
             throw new RuntimeException(sprintf('Ошибка получения данных (%s).', $response->text), $response->code);
         }

--- a/src/back/Update/TorrentsClients.php
+++ b/src/back/Update/TorrentsClients.php
@@ -216,11 +216,18 @@ final class TorrentsClients
 
                 if ($countUntracked > 150) {
                     $this->logger->notice(
-                        'Хранится много сторонних раздач. Рекомендуется отключить поиск сторонних раздач или добавить подразделы в хранимые.'
+                        'Хранится много сторонних раздач ({count} шт.). Рекомендуется отключить поиск сторонних раздач или добавить подразделы в хранимые.',
+                        ['count' => $countUntracked]
                     );
                 }
 
                 // Пробуем найти в API раздачи по их хешам из клиента.
+
+                $this->logger->debug(
+                    'Получаем сведения о сторонних раздачах ({count} шт.) по их хешам через API...',
+                    ['count' => $countUntracked]
+                );
+
                 $response = $this->apiClient->getTopicsDetails($untrackedTorrentHashes, TopicSearchMode::HASH);
 
                 if ($response instanceof ApiError) {


### PR DESCRIPTION
- Added code to avoid triggering API rate limit (503 errors).
- Added new configuration parameter api_request_threshold with default 0.5 seconds; the value is configurable in the ini file without currently an intent of modifying it via the GUI as the limit is currently fixed at the server side, see https://rutracker.org/forum/viewtopic.php?p=75760916#75760916
- Added notice/debug log entries before API calls.
- Removed the implicit parameters to allow future parameter expansion (updated API calls to specify search mode explicitly.
- Removed default value for $timeout parameter in createApiClient method, making it mandatory).