### PR TITLE
Обработка ограничений доступа к API для кандидатов в хранители

### DIFF
--- a/src/back/Data/KeeperPermissions.php
+++ b/src/back/Data/KeeperPermissions.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KeepersTeam\Webtlo\Data;
+
+/**
+ * Статус хранителя, с точки зрения API и ограничения доступа, если есть.
+ */
+final class KeeperPermissions
+{
+    /**
+     * @var list<int>
+     */
+    private array $skipped = [];
+
+    /**
+     * @param null|list<int> $allowedSubsections
+     */
+    public function __construct(
+        public readonly bool   $isCurator,
+        public readonly bool   $isCandidate,
+        public readonly ?array $allowedSubsections = null,
+    ) {}
+
+    /**
+     * Имеет ли кандидат доступ к заданному подразделу.
+     */
+    public function checkSubsectionAccess(int $forumId): bool
+    {
+        if ($this->allowedSubsections === null) {
+            return true;
+        }
+
+        if (!in_array($forumId, $this->allowedSubsections, true)) {
+            $this->skipped[] = $forumId;
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @return list<int>
+     */
+    public function getSkippedSubsections(): array
+    {
+        $skipped = array_values(array_unique($this->skipped));
+        sort($skipped);
+
+        return $skipped;
+    }
+}

--- a/src/back/Module/Report/SendReport.php
+++ b/src/back/Module/Report/SendReport.php
@@ -6,6 +6,7 @@ namespace KeepersTeam\Webtlo\Module\Report;
 
 use DateTimeInterface;
 use KeepersTeam\Webtlo\Config\ApiCredentials;
+use KeepersTeam\Webtlo\Data\KeeperPermissions;
 use KeepersTeam\Webtlo\External\ApiReport\KeepingStatuses;
 use KeepersTeam\Webtlo\External\ApiReportClient;
 use KeepersTeam\Webtlo\External\ForumClient;
@@ -31,6 +32,14 @@ final class SendReport
     public function checkApiAccess(): void
     {
         $this->setApiEnable($this->apiReport->checkAccess());
+    }
+
+    /**
+     * Ограничения доступа для кандидатов в хранители.
+     */
+    public function getKeeperPermissions(): KeeperPermissions
+    {
+        return $this->apiReport->getKeeperPermissions();
     }
 
     /**


### PR DESCRIPTION
С недавних пор кандидат в хранители нзапрещено получать данные и изменять статус хранения раздач в подразделах, которые ему не отметил куратор.

- Добавлен класс `KeeperPermissions` для хранения текущего "статуса" хранителя.
- Добавлен метод для получения и обработки статуса хранителя и его "отмеченных" в API хранимых подразделов.
- Добавлены проверки возможности взаимодействия кандидата в хранителя с различными процессами:
   - получение раздач в хранимых подразделах
   - получение списков хранителей в этих подразделах
   - отправка отчётов по таким подразделам
 
В случае отсутствия доступа будет уведомление вида:
```
INFO: Обнаружены ограничения доступа к API отчётов. {"allowed_subforums":[1030]}
NOTICE: У кандидата в хранители нет доступа к указанным подразделам. Обратитесь к куратору. {"skipped":[908,357]}
```
