### PR TITLE
Включаем поиск разрегов, теперь с помощью API отчётов

### DIFF
--- a/src/back/Enum/TorrentStatus.php
+++ b/src/back/Enum/TorrentStatus.php
@@ -55,6 +55,15 @@ enum TorrentStatus: int
         return in_array($this, self::VALID, true);
     }
 
+    public function getGroupName(): string
+    {
+        if ($this->isValid()) {
+            return sprintf('обновлено (%s)', $this->label());
+        }
+
+        return sprintf('закрыто (%s)', $this->label());
+    }
+
     /**
      * Валидный ли статус раздачи.
      */

--- a/src/back/External/ApiReport/Actions/TopicsDetails.php
+++ b/src/back/External/ApiReport/Actions/TopicsDetails.php
@@ -260,15 +260,44 @@ trait TopicsDetails
             $format = $result['columns'];
 
             foreach ($result['releases'] as $data) {
-                // Проверим, что последняя версия релиза есть.
-                $lastVersion = $data['versions'][0] ?? null;
-                if (!is_array($lastVersion)) {
+                if (empty($data['versions'])) {
                     continue;
                 }
 
-                $knownTopics[] = self::parseDynamicTopicDetails(
-                    payload: array_combine($format, $lastVersion)
+                // Считаем актуальной версией первую в списке.
+                $actualVersion = array_shift($data['versions']);
+                if (!is_array($actualVersion)) {
+                    continue;
+                }
+
+                $topic = self::parseDynamicTopicDetails(
+                    payload: array_combine($format, $actualVersion)
                 );
+
+                // Попробуем найти совпадение по искомому хешу.
+                if (!empty($data['requested_info_hash']) && count($data['versions'])) {
+                    $hashKeyIndex = array_flip($format)['info_hash'];
+
+                    $searchedVersion = null;
+                    foreach ($data['versions'] as $version) {
+                        if ($data['requested_info_hash'] === $version[$hashKeyIndex]) {
+                            $searchedVersion = $version;
+
+                            break;
+                        }
+                    }
+
+                    // Если нашли совпадение по хешу, значит раздачу обновили. Записываем обе версии.
+                    if (is_array($searchedVersion)) {
+                        $topic = self::parseDynamicTopicDetails(
+                            payload      : array_combine($format, $searchedVersion),
+                            actualVersion: $topic,
+                        );
+                    }
+                }
+
+                // Записываем найденное.
+                $knownTopics[] = $topic;
             }
 
             // Оставим для отладки.
@@ -279,19 +308,20 @@ trait TopicsDetails
     /**
      * @param array<array-key, int|string> $payload
      */
-    private static function parseDynamicTopicDetails(array $payload): TopicDetails
+    private static function parseDynamicTopicDetails(array $payload, ?TopicDetails $actualVersion = null): TopicDetails
     {
         return new TopicDetails(
-            id        : (int) $payload['topic_id'],
-            hash      : (string) $payload['info_hash'],
-            forumId   : (int) $payload['subforum_id'],
-            poster    : (int) $payload['topic_poster'],
-            size      : (int) $payload['tor_size_bytes'],
-            registered: self::parseDateTime((string) $payload['reg_time']),
-            status    : TorrentStatus::from((int) $payload['tor_status']),
-            priority  : KeepingPriority::from((int) $payload['keeping_priority']),
-            seeders   : (int) $payload['seeders'],
-            title     : (string) $payload['topic_title'],
+            id           : (int) $payload['topic_id'],
+            hash         : (string) $payload['info_hash'],
+            forumId      : (int) $payload['subforum_id'],
+            poster       : (int) $payload['topic_poster'],
+            size         : (int) $payload['tor_size_bytes'],
+            registered   : self::parseDateTime((string) $payload['reg_time']),
+            status       : TorrentStatus::from((int) $payload['tor_status']),
+            priority     : KeepingPriority::from((int) $payload['keeping_priority']),
+            seeders      : (int) $payload['seeders'],
+            title        : (string) $payload['topic_title'],
+            actualVersion: $actualVersion
         );
     }
 

--- a/src/back/External/Data/TopicDetails.php
+++ b/src/back/External/Data/TopicDetails.php
@@ -8,9 +8,24 @@ use DateTimeImmutable;
 use KeepersTeam\Webtlo\Enum\KeepingPriority;
 use KeepersTeam\Webtlo\Enum\TorrentStatus;
 
-/** Дополнительные сведения о раздаче. */
+/**
+ * Дополнительные сведения о раздаче.
+ */
 final class TopicDetails
 {
+    /**
+     * @param int               $id            ид раздачи
+     * @param string            $hash          хеш раздачи
+     * @param int               $forumId       ид подраздела на форуме
+     * @param int               $poster        ид автора раздачи
+     * @param int               $size          размер раздачи в байтах
+     * @param DateTimeImmutable $registered    дата регистрации
+     * @param TorrentStatus     $status        статус раздачи на форуме
+     * @param KeepingPriority   $priority      приоритет хранения
+     * @param int               $seeders       количество сидов на раздаче
+     * @param string            $title         наименование
+     * @param ?TopicDetails     $actualVersion актуальная версия раздачи, если есть
+     */
     public function __construct(
         public readonly int               $id,
         public readonly string            $hash,
@@ -22,5 +37,6 @@ final class TopicDetails
         public readonly KeepingPriority   $priority,
         public readonly int               $seeders,
         public readonly string            $title,
+        public readonly ?TopicDetails     $actualVersion = null,
     ) {}
 }

--- a/src/back/Storage/Clone/Torrents.php
+++ b/src/back/Storage/Clone/Torrents.php
@@ -110,7 +110,7 @@ final class Torrents
     {
         $tab = $this->clone->getTableObject();
 
-        $stm = $this->db->executeStatement(
+        return $this->db->query(
             "
                 SELECT tmp.info_hash
                 FROM $tab->clone AS tmp
@@ -119,10 +119,9 @@ final class Torrents
                     Topics.id IS NULL
                     OR Topics.forum_id NOT IN ($subsections->keys)
             ",
-            $subsections->values
+            $subsections->values,
+            PDO::FETCH_COLUMN
         );
-
-        return $stm->fetchAll(PDO::FETCH_COLUMN);
     }
 
     public function clearOriginTable(): void

--- a/src/back/Update/TorrentsClients.php
+++ b/src/back/Update/TorrentsClients.php
@@ -240,7 +240,7 @@ final class TorrentsClients
 
             if ($response instanceof ApiError) {
                 $this->logger->debug(
-                    'Не удалось найти данные о раздачах в API. {code}: {text}',
+                    'Не удалось найти данные о сторонник раздачах в API. {code}: {text}',
                     ['code' => $response->code, 'text' => $response->text]
                 );
 
@@ -248,6 +248,16 @@ final class TorrentsClients
 
                 return;
             }
+
+            $this->logger->debug(
+                'Поиск сторонник раздач в API завершён. '
+                . 'Найдено актуальных {actual} шт., устаревших {old} шт., не найдено {missed} шт.',
+                [
+                    'actual' => count($response->actualTopics),
+                    'old'    => count($response->oldTopics),
+                    'missed' => count($response->missingTopics),
+                ]
+            );
 
             unset($untrackedTorrentHashes);
 
@@ -305,32 +315,32 @@ final class TorrentsClients
             Timers::start('search_unregistered');
             $unregisteredTopics = $this->cloneUnregistered->searchUnregisteredTopics();
 
-            // Если в БД есть разрегистрированные раздачи, ищем их статус на форуме.
+            // Если в БД есть разрегистрированные раздачи, ищем их в результатах поиска в API.
             if (count($unregisteredTopics)) {
                 foreach ($unregisteredTopics as $topicId => $infoHash) {
                     // Если о раздаче есть данные в API, то дописываем их, как более верные.
-                    $topicData = $this->getApiTopicInfo(infoHash: $infoHash);
-                    if ($topicData === null) {
+                    $topic = $this->getApiTopicInfo(infoHash: $infoHash);
+                    if ($topic === null) {
                         continue;
                     }
 
-                    $status = 'неизвестно';
-                    if (!$topicData->status->isValid()) {
-                        $status = $topicData->status->label();
+                    // Если у раздачи есть новая версия, то используем её данные.
+                    if ($topic->actualVersion !== null) {
+                        $topic = $topic->actualVersion;
                     }
 
-                    // Записываем данные раздачи в буфер.
+                    // Записываем данные раздачи в буферную таблицу.
                     $this->cloneUnregistered->addTopic(topic: [
-                        $infoHash,
-                        $topicData->title,
-                        $status,
-                        $topicData->priority->label(),
+                        $infoHash, // Текущий хеш раздачи, который в клиенте.
+                        $topic->title,
+                        $topic->status->getGroupName(),
+                        $topic->priority->label(),
                         '',
                         '',
                         '',
                     ]);
 
-                    unset($topicId, $topicData);
+                    unset($topicId, $topic);
                 }
 
                 $this->cloneUnregistered->fillTempTable();


### PR DESCRIPTION
related #561 

Теперь будет выполнятся поиск "прошлых версий" раздачи по совпадению текущего известного хеша в клиенте.
Если в апи будет совпадение, то последняя известная версия = актуальная.
Если статус актуальной версии валидный, то считаем, что раздача "обновлена". Если не валидный - то "закрыта".

В случае если в апи нет никаких новых сведений (новой актуальной версии), но раздача присутствует в выдаче - значит раздача закрыли, но со статусами беда.

С такими раздачами пока будут странные коллизии в выводимой информации. 