### PR TITLE
Доработка поиска "прочих" и "разрегов"

### DIFF
--- a/src/back/External/ApiReport/Actions/TopicsDetails.php
+++ b/src/back/External/ApiReport/Actions/TopicsDetails.php
@@ -18,7 +18,7 @@ use KeepersTeam\Webtlo\External\Data\TopicSearchMode;
 use Psr\Http\Message\ResponseInterface;
 
 /**
- * @phpstan-type RequestTopics (int|string)[]
+ * @phpstan-type RequestTopics int[]|string[]
  * @phpstan-type TopicsChunks RequestTopics[]
  * @phpstan-type RequestFactory callable(): PromiseInterface
  * @phpstan-type PromiseProcessor callable(ResponseInterface, int): void
@@ -32,7 +32,7 @@ trait TopicsDetails
      */
     public function getTopicsDetails(
         array           $topics,
-        TopicSearchMode $searchMode = TopicSearchMode::ID,
+        TopicSearchMode $searchMode = TopicSearchMode::HASH,
     ): ApiError|TopicsDetailsResponse {
         // Ищем раздачи в актуальном API.
         $actualTopics = $this->getTopicsDetailsConcurrently(
@@ -101,7 +101,7 @@ trait TopicsDetails
     ): ApiError|array {
         $knownTopics = [];
 
-        $topicChunks  = array_chunk($topics, $searchMode->paramsLimit());
+        $topicChunks  = array_chunk($topics, $searchMode->postParamChunkSize());
         $requestCount = count($topicChunks);
 
         $pool = new Pool(
@@ -144,7 +144,7 @@ trait TopicsDetails
         // Параметры для каждого запроса в Pool.
         $options = [
             'mode'    => $searchMode->value,
-            'columns' => implode(',', $columns),
+            'columns' => $columns,
         ];
 
         /**
@@ -153,14 +153,14 @@ trait TopicsDetails
          * @return Generator<RequestFactory>
          */
         return static function(array $topicsChunks) use ($client, $options): Generator {
-            foreach ($topicsChunks as $requestTopics) {
-                yield static function() use ($client, $options, $requestTopics) {
-                    return $client->getAsync(
+            foreach ($topicsChunks as $topics) {
+                yield static function() use ($client, $options, $topics) {
+                    return $client->postAsync(
                         uri    : 'releases/pvc',
                         options: [
-                            'query' => [
+                            'json' => [
                                 ...$options,
-                                'topic_ids' => implode(',', $requestTopics),
+                                'topic_ids' => $topics,
                             ],
                         ]
                     );
@@ -184,8 +184,13 @@ trait TopicsDetails
         return static function(array $topicsChunks) use ($client): Generator {
             foreach ($topicsChunks as $topics) {
                 yield static function() use ($client, $topics) {
-                    return $client->getAsync(
-                        uri: 'old_releases_versions/' . implode(',', $topics),
+                    return $client->postAsync(
+                        uri    : 'old_releases_versions',
+                        options: [
+                            'json' => [
+                                'topic_ids_or_hashes' => $topics,
+                            ],
+                        ],
                     );
                 };
             }

--- a/src/back/External/ApiReport/Actions/TopicsPeers.php
+++ b/src/back/External/ApiReport/Actions/TopicsPeers.php
@@ -15,7 +15,7 @@ use KeepersTeam\Webtlo\External\Data\TopicsPeersResponse;
 use Psr\Http\Message\ResponseInterface;
 
 /**
- * @phpstan-type RequestTopics (int|string)[]
+ * @phpstan-type RequestTopics int[]|string[]
  * @phpstan-type TopicsChunks RequestTopics[]
  * @phpstan-type RequestFactory callable(): PromiseInterface
  * @phpstan-type PromiseProcessor callable(ResponseInterface, int): void
@@ -37,7 +37,7 @@ trait TopicsPeers
         $fulfilledProcessor = $this->getPeersPayloadProcessor(...);
         $requestGenerator   = $this->getPeersRequestGenerator(searchMode: $searchMode);
 
-        $topicChunks  = array_chunk($topics, $searchMode->paramsLimit());
+        $topicChunks  = array_chunk($topics, $searchMode->postParamChunkSize());
         $requestCount = count($topicChunks);
 
         $pool = new Pool(
@@ -90,7 +90,7 @@ trait TopicsPeers
         // Параметры для каждого запроса в Pool.
         $options = [
             'mode'    => $searchMode->value,
-            'columns' => implode(',', $columns),
+            'columns' => $columns,
         ];
 
         /**
@@ -101,12 +101,12 @@ trait TopicsPeers
         return static function(array $topicsChunks) use ($client, $options): Generator {
             foreach ($topicsChunks as $requestTopics) {
                 yield static function() use ($client, $options, $requestTopics) {
-                    return $client->getAsync(
+                    return $client->postAsync(
                         uri    : 'releases/pvc',
                         options: [
-                            'query' => [
+                            'json' => [
                                 ...$options,
-                                'topic_ids' => implode(',', $requestTopics),
+                                'topic_ids' => $requestTopics,
                             ],
                         ]
                     );

--- a/src/back/External/Data/TopicSearchMode.php
+++ b/src/back/External/Data/TopicSearchMode.php
@@ -4,24 +4,24 @@ declare(strict_types=1);
 
 namespace KeepersTeam\Webtlo\External\Data;
 
-/** Тип поиска раздач. */
+/**
+ * Тип поиска раздач.
+ */
 enum TopicSearchMode: string
 {
-    case ID   = 'topic_id';
+    case ID   = 'id';
     case HASH = 'hash';
 
     /**
+     * Количество раздач (параметров) в одном запросе для POST запроса.
+     *
      * @return positive-int
      */
-    public function paramsLimit(): int
+    public function postParamChunkSize(): int
     {
         return match ($this) {
-            self::ID   => 100,
-            /*
-             * Hashes are longer, so to avoid HTTP 414 in legacy API
-             * we're capping max identifiers per request.
-             */
-            self::HASH => 32,
+            self::ID   => 1500,
+            self::HASH => 1000,
         };
     }
 }

--- a/src/back/Storage/Clone/TopicsUnregistered.php
+++ b/src/back/Storage/Clone/TopicsUnregistered.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace KeepersTeam\Webtlo\Storage\Clone;
 
-use KeepersTeam\Webtlo\Infrastructure\Database\ConnectionInterface;
 use KeepersTeam\Webtlo\Storage\CloneTable;
-use PDO;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -31,31 +29,9 @@ final class TopicsUnregistered
     private array $topics = [];
 
     public function __construct(
-        private readonly ConnectionInterface $db,
-        private readonly LoggerInterface     $logger,
-        private readonly CloneTable          $clone,
+        private readonly LoggerInterface $logger,
+        private readonly CloneTable      $clone,
     ) {}
-
-    /**
-     * @return array<int, string>
-     */
-    public function searchUnregisteredTopics(): array
-    {
-        return $this->db->query(
-            sql  : "
-                SELECT
-                    Torrents.topic_id,
-                    Torrents.info_hash
-                FROM Torrents
-                LEFT JOIN Topics ON Topics.info_hash = Torrents.info_hash
-                LEFT JOIN TopicsUntracked ON TopicsUntracked.info_hash = Torrents.info_hash
-                WHERE Topics.info_hash IS NULL
-                    AND TopicsUntracked.info_hash IS NULL
-                    AND Torrents.topic_id <> ''
-            ",
-            pdo  : PDO::FETCH_KEY_PAIR
-        );
-    }
 
     /**
      * @param array<int, mixed> $topic
@@ -66,27 +42,21 @@ final class TopicsUnregistered
     }
 
     /**
-     * Записать раздачи во временную таблицу.
-     */
-    public function fillTempTable(): void
-    {
-        $rows = array_map(fn($el) => array_combine($this->clone->getTableKeys(), $el), $this->topics);
-
-        $this->clone->cloneFillChunk(dataSet: $rows);
-
-        $this->topics = [];
-    }
-
-    /**
      * Перенести данные о раздачах в основную таблицу БД.
      */
     public function moveToOrigin(): void
     {
-        $count = $this->clone->cloneCount();
-        if ($count > 0) {
-            $this->logger->info('Найдено разрегистрированных или обновлённых раздач: {count} шт.', ['count' => $count]);
-            $this->clone->moveToOrigin();
+        if (!count($this->topics)) {
+            return;
         }
+
+        $this->logger->info('Найдено разрегистрированных или обновлённых раздач: {count} шт.', ['count' => count($this->topics)]);
+
+        $rows = array_map(fn($el) => array_combine($this->clone->getTableKeys(), $el), $this->topics);
+
+        $this->clone->cloneFillChunk(dataSet: $rows);
+
+        $this->clone->writeTable();
     }
 
     /**

--- a/src/back/Storage/CloneFactory.php
+++ b/src/back/Storage/CloneFactory.php
@@ -133,7 +133,6 @@ final class CloneFactory
         );
 
         return new TopicsUnregistered(
-            db    : $this->con,
             logger: $this->logger,
             clone : $table,
         );

--- a/src/back/Update/TorrentsClients.php
+++ b/src/back/Update/TorrentsClients.php
@@ -13,7 +13,6 @@ use KeepersTeam\Webtlo\Enum\UpdateMark;
 use KeepersTeam\Webtlo\External\ApiReportClient;
 use KeepersTeam\Webtlo\External\Data\ApiError;
 use KeepersTeam\Webtlo\External\Data\TopicDetails;
-use KeepersTeam\Webtlo\External\Data\TopicSearchMode;
 use KeepersTeam\Webtlo\Storage\Clone\TopicsUnregistered;
 use KeepersTeam\Webtlo\Storage\Clone\TopicsUntracked;
 use KeepersTeam\Webtlo\Storage\Clone\Torrents;
@@ -30,7 +29,7 @@ final class TorrentsClients
     private array $timers = [];
 
     /** @var TopicDetails[] */
-    private array $unregisteredApiTopics = [];
+    private array $unregisteredTopics = [];
 
     /**
      * @param Torrents           $cloneTorrents     таблица хранимых раздач в торрент-клиентах
@@ -188,13 +187,13 @@ final class TorrentsClients
     private function updateUntracked(): void
     {
         try {
+            $searchUntracked    = $this->topicSearch->untracked;
+            $searchUnregistered = $this->topicSearch->unregistered;
+
             // Выключено - прекращаем работу.
-            if (!$this->topicSearch->untracked) {
+            if (!$searchUntracked && !$searchUnregistered) {
                 return;
             }
-
-            // Включён ли поиск разрегистрированных раздач.
-            $searchUnregistered = $this->topicSearch->unregistered;
 
             Timers::start('search_untracked');
 
@@ -213,21 +212,19 @@ final class TorrentsClients
                 ['count' => $countUntracked]
             );
 
-            if ($countUntracked > 150) {
+            $countLimit = 10_000;
+            if ($countUntracked > $countLimit) {
                 $this->logger->notice(
                     'Хранится много сторонних раздач. Рекомендуется отключить поиск сторонних раздач или добавить подразделы в хранимые.'
                 );
 
                 // Обрежем раздачи, если их слишком много.
-                $countLimit = rand(256, 512);
-                if ($countUntracked > $countLimit) {
-                    $this->logger->warning(
-                        'Будет произведён анализ первых {limit} из {total} сторонних раздач.',
-                        ['limit' => $countLimit, 'total' => $countUntracked]
-                    );
+                $this->logger->warning(
+                    'Будет произведён анализ первых {limit} из {total} сторонних раздач.',
+                    ['limit' => $countLimit, 'total' => $countUntracked]
+                );
 
-                    $untrackedTorrentHashes = array_slice($untrackedTorrentHashes, 0, $countLimit);
-                }
+                $untrackedTorrentHashes = array_slice($untrackedTorrentHashes, 0, $countLimit);
             }
 
             // Проверим доступность API отчётов перед попыткой поиска раздач.
@@ -236,10 +233,7 @@ final class TorrentsClients
             }
 
             // Пробуем найти в API раздачи по их хешам из клиента.
-            $response = $this->apiClient->getTopicsDetails(
-                topics    : $untrackedTorrentHashes,
-                searchMode: TopicSearchMode::HASH
-            );
+            $response = $this->apiClient->getTopicsDetails(topics: $untrackedTorrentHashes);
 
             if ($response instanceof ApiError) {
                 $this->logger->debug(
@@ -247,7 +241,7 @@ final class TorrentsClients
                     ['code' => $response->code, 'text' => $response->text]
                 );
 
-                $this->logger->debug('hashes', $untrackedTorrentHashes);
+                $this->logger->debug('hashes', array_slice($untrackedTorrentHashes, 0, 50));
 
                 return;
             }
@@ -269,18 +263,21 @@ final class TorrentsClients
                 foreach ($response->actualTopics as $topic) {
                     // Пропускаем раздачи в невалидных статусах.
                     if (!$topic->status->isValid()) {
-                        // Дописываем их в буфер если нужны.
+                        // Дописываем их в буфер если включено.
                         if ($searchUnregistered) {
-                            $this->unregisteredApiTopics[$topic->hash] = $topic;
+                            $this->unregisteredTopics[$topic->hash] = $topic;
                         }
 
                         continue;
                     }
 
-                    $this->cloneUntracked->addTopic(topic: $topic);
+                    // Записываем прочие раздачи, если включено.
+                    if ($searchUntracked) {
+                        $this->cloneUntracked->addTopic(topic: $topic);
+                    }
                 }
 
-                // Если нашлись существующие на форуме раздачи, то записываем их в БД.
+                // Если нашлись существующие раздачи, то записываем их в БД.
                 $this->cloneUntracked->moveToOrigin();
             }
 
@@ -288,7 +285,7 @@ final class TorrentsClients
             if (count($response->oldTopics) && $searchUnregistered) {
                 foreach ($response->oldTopics as $topic) {
                     // Дописываем их в буфер если нужны.
-                    $this->unregisteredApiTopics[$topic->hash] = $topic;
+                    $this->unregisteredTopics[$topic->hash] = $topic;
                 }
             }
         } catch (Throwable $e) {
@@ -311,58 +308,53 @@ final class TorrentsClients
     {
         try {
             // Выключено - прекращаем работу.
-            if (!$this->topicSearch->untracked || !$this->topicSearch->unregistered) {
+            if (!$this->topicSearch->unregistered) {
+                return;
+            }
+
+            // Если нет подходящих раздач, выходим.
+            if (!count($this->unregisteredTopics)) {
                 return;
             }
 
             Timers::start('search_unregistered');
-            $unregisteredTopics = $this->cloneUnregistered->searchUnregisteredTopics();
+            foreach ($this->unregisteredTopics as $topic) {
+                // Сохраняем исходных хеш раздачи из клиента.
+                $infoHash = $topic->hash;
 
-            // Если в БД есть разрегистрированные раздачи, ищем их в результатах поиска в API.
-            if (count($unregisteredTopics)) {
-                foreach ($unregisteredTopics as $topicId => $infoHash) {
-                    // Если о раздаче есть данные в API, то дописываем их, как более верные.
-                    $topic = $this->getApiTopicInfo(infoHash: $infoHash);
-                    if ($topic === null) {
-                        continue;
-                    }
-
-                    // Если у раздачи есть новая версия, то используем её данные.
-                    if ($topic->actualVersion !== null) {
-                        $topic = $topic->actualVersion;
-                    }
-
-                    // Берём статус из известной (актуальной) версии раздачи.
-                    if ($topic->status->isValid()) {
-                        $topicStatus = sprintf('обновлено (%s)', $topic->status->label());
-                    } else {
-                        $topicStatus = sprintf('закрыто (%s)', $topic->status->label());
-                    }
-
-                    /**
-                     * Если хеш раздачи в клиенте и хеш известной версии совпадают,
-                     * но раздачу нашли в "прошлых" версиях, что значит что раздача точно "разрег".
-                     * Значит отмечаем как "неизвестно", на всякий случай.
-                     */
-                    if ($infoHash === $topic->hash && $topic->status->isValid()) {
-                        $topicStatus = 'закрыто (неизвестно)';
-                    }
-
-                    // Записываем данные раздачи в буферную таблицу.
-                    $this->cloneUnregistered->addTopic(topic: [
-                        $infoHash, // Текущий хеш раздачи, который в клиенте.
-                        $topic->title,
-                        $topicStatus,
-                        $topic->priority->label(),
-                        '',
-                        '',
-                        '',
-                    ]);
-
-                    unset($topicId, $topic);
+                // Если у раздачи есть новая версия, то используем её данные.
+                if ($topic->actualVersion !== null) {
+                    $topic = $topic->actualVersion;
                 }
 
-                $this->cloneUnregistered->fillTempTable();
+                // Берём статус из известной (актуальной) версии раздачи.
+                if ($topic->status->isValid()) {
+                    $topicStatus = sprintf('обновлено (%s)', $topic->status->label());
+                } else {
+                    $topicStatus = sprintf('закрыто (%s)', $topic->status->label());
+                }
+
+                /**
+                 * Если хеш раздачи в клиенте и хеш известной версии совпадают,
+                 * но раздачу нашли в "прошлых" версиях, что значит что раздача точно "разрег".
+                 * Значит отмечаем как "неизвестно", на всякий случай.
+                 */
+                if ($infoHash === $topic->hash && $topic->status->isValid()) {
+                    $topicStatus = 'закрыто (неизвестно)';
+                }
+
+                // Записываем данные раздачи в буферную таблицу.
+                $this->cloneUnregistered->addTopic(topic: [
+                    $infoHash,
+                    $topic->title,
+                    $topicStatus,
+                    $topic->priority->label(),
+                    '',
+                    '',
+                    '',
+                ]);
+
+                unset($infoHash, $topic);
             }
 
             $this->cloneUnregistered->moveToOrigin();
@@ -377,14 +369,5 @@ final class TorrentsClients
             // Очищаем ненужные строки.
             $this->cloneUnregistered->clearUnusedRows();
         }
-    }
-
-    private function getApiTopicInfo(string $infoHash): ?TopicDetails
-    {
-        if (isset($this->unregisteredApiTopics[$infoHash])) {
-            return $this->unregisteredApiTopics[$infoHash];
-        }
-
-        return null;
     }
 }


### PR DESCRIPTION
close #585

- При поиске сведений о раздачах по ид/хешу теперь используем `POST` вместо `GET` при опросе API, что позволило увеличить количество запрашиваемых раздач в ~30 раз за запрос.
- - Используется для поиска "прочих", "разрегов" и регулировки "прочих".
- Поиск разрегов более не использует БД как буфер для определения "разрега" из "прочего", теперь это определяется по ответу API.
- Лимит общего количества "прочих", который подвергался анализу увеличен с ~500 штук до 10_000 штук.