### PR TITLE
Dev/download files from api

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -489,6 +489,10 @@ button.settings-button {
     text-align: right;
 }
 
+.prop-width-5em {
+    width: 5em;
+}
+
 .forum-profile-link {
     cursor: pointer;
 }

--- a/public/index.php
+++ b/public/index.php
@@ -328,10 +328,7 @@ $cs = function(string $section, string $key, int|string $default = '') use ($con
                                 </fieldset>
                             </div>
                             <div class="filter_block ui-widget"
-                                 title="Статус определяется при сканировании списков хранимого на форуме и обновлении сведений через API форума. Каждая раздача может иметь (или не иметь):
-                                 'Хранителя', который скачал раздачу и включил её в свой отчёт;
-                                 'Хранителя', который раздаёт раздачу на момент последнего обновления сведений;
-                                 'Хранителя', который скачивает раздачу.">
+                                 title="Статус определяется при сканировании списков хранимого на форуме и обновлении сведений через API форума. Каждая раздача может иметь (или не иметь):&#10;- 'Хранителя', который скачал раздачу и включил её в свой отчёт;&#10;- 'Хранителя', который раздаёт раздачу на момент последнего обновления сведений;&#10;- 'Хранителя', который скачивает раздачу.">
                                 <span>Статус хранения раздачи</span>
                                 <hr/>
                                 <fieldset class="filter-topic-kept-status">
@@ -591,44 +588,34 @@ $cs = function(string $section, string $key, int|string $default = '') use ($con
                             <div id="proxy_prop">
                             <h2>Настройки прокси-сервера</h2>
                                 <div>
-                                    <label>
-                                        Тип:
-                                        <select name="proxy_type" id="proxy_type" class="inline-input" title="Тип прокси-сервера">
-                                            <?= $cs('proxy', 'options'); ?>
-                                        </select>
-                                    </label>
+                                    <label for="proxy_type" class="prop-inline-block prop-width-5em">Тип:</label>
+                                    <select name="proxy_type" id="proxy_type" class="inline-input" title="Тип прокси-сервера">
+                                        <?= $cs('proxy', 'options'); ?>
+                                    </select>
                                 </div>
                                 <div>
-                                    <label>
-                                        Адрес:
-                                        <input name="proxy_hostname" id="proxy_hostname" type="text"
-                                               class="inline-input" size="24"
-                                               title="IP-адрес или сетевое/доменное имя прокси-сервера."
-                                               value="<?= $cs('proxy', 'hostname'); ?>"/>
-                                    </label>
-                                    <label>
-                                        Порт:
-                                        <input name="proxy_port" id="proxy_port" type="text"
-                                               class="inline-input" size="6"
-                                               title="Порт прокси-сервера."
-                                               value="<?= $cs('proxy', 'port'); ?>"/>
-                                    </label>
+                                    <label for="proxy_hostname" class="prop-inline-block prop-width-5em">Адрес:</label>
+                                    <input name="proxy_hostname" id="proxy_hostname" type="text"
+                                           class="inline-input" size="17"
+                                           title="IP-адрес или сетевое/доменное имя прокси-сервера."
+                                           value="<?= $cs('proxy', 'hostname'); ?>"/>
+                                    <label for="proxy_port" class="prop-inline-block prop-width-5em">Порт:</label>
+                                    <input name="proxy_port" id="proxy_port" type="text"
+                                           class="inline-input" size="6"
+                                           title="Порт прокси-сервера."
+                                           value="<?= $cs('proxy', 'port'); ?>"/>
                                 </div>
                                 <div>
-                                    <label>
-                                        Логин:
-                                        <input name="proxy_login" id="proxy_login" type="text"
-                                               class="inline-input" size="24"
-                                               title="Имя пользователя для доступа к прокси-серверу (необязательно)."
-                                               value="<?= $cs('proxy', 'username'); ?>"/>
-                                    </label>
-                                    <label>
-                                        Пароль:
-                                        <input name="proxy_paswd" id="proxy_paswd" type="password"
-                                               class="inline-input user_protected" size="24"
-                                               title="Пароль для доступа к прокси-серверу (необязатально)."
-                                               value="<?= $cs('proxy', 'password'); ?>"/>
-                                    </label>
+                                    <label for="proxy_login" class="prop-inline-block prop-width-5em">Логин:</label>
+                                    <input name="proxy_login" id="proxy_login" type="text"
+                                           class="inline-input" size="17"
+                                           title="Имя пользователя для доступа к прокси-серверу (необязательно)."
+                                           value="<?= $cs('proxy', 'username'); ?>"/>
+                                    <label for="proxy_paswd" class="prop-inline-block prop-width-5em">Пароль:</label>
+                                    <input name="proxy_paswd" id="proxy_paswd" type="password"
+                                           class="inline-input user_protected" size="17"
+                                           title="Пароль для доступа к прокси-серверу (необязатально)."
+                                           value="<?= $cs('proxy', 'password'); ?>"/>
                                 </div>
                             </div>
                         </div>
@@ -846,10 +833,28 @@ $cs = function(string $section, string $key, int|string $default = '') use ($con
                         </div>
                         <h2>Скачивание торрент-файлов</h2>
                         <div>
-                            <h3>Каталог для скачиваемых *.torrent файлов</h3>
+                            <h3>Откуда загружать *.torrent-файлы</h3>
+                            <label title="- Выключено (По умолчанию) *.torrent-файлы будут загружены с форума. &#10;- Включено, *.torrent-файлы будут загружены через API отчётов. &#10;&#10;См `Связь с форумом и API`">
+                                <input name="download_api_proxy" type="checkbox" size="24"
+                                    <?= $cs('torrentDownload', 'useApiProxy'); ?>
+                                />
+                                загружать файлы через API отчётов.
+                            </label>
+                            <hr>
+
+                            <h3>Настройки retracker.local</h3>
+                            <label title="Добавлять retracker.local в скачиваемые *.torrent-файлы. Влияет на добавляемые в клиент файлы и на файлы скачиваемые в каталог.">
+                                <input name="retracker" type="checkbox" size="24"
+                                    <?= $cs('torrentDownload', 'addRetracker'); ?>
+                                />
+                                добавлять retracker.local в скачиваемые *.torrent-файлы
+                            </label>
+                            <hr>
+                            <h3>Загрузка *.torrent файлов со своим PASSKEY</h3>
                             <div>
+                                Каталог:
                                 <input id="savedir" name="savedir" class="inline-input" type="text" size="53"
-                                       title="Каталог, куда будут сохраняться новые *.torrent-файлы."
+                                       title="Каталог, в который будут сохранены загруженные torrent-файлы с учётными данными авторизованного хранителя."
                                        value="<?= $cs('torrentDownload', 'folder'); ?>"
                                 />
                             </div>
@@ -859,18 +864,12 @@ $cs = function(string $section, string $key, int|string $default = '') use ($con
                                 />
                                 создавать подкаталоги
                             </label>
-                            <h3>Настройки retracker.local</h3>
-                            <label title="Добавлять retracker.local в скачиваемые *.torrent-файлы.">
-                                <input name="retracker" type="checkbox" size="24"
-                                    <?= $cs('torrentDownload', 'addRetracker'); ?>
-                                />
-                                добавлять retracker.local в скачиваемые *.torrent-файлы
-                            </label>
-                            <h3>Скачивание *.torrent файлов с заменой Passkey</h3>
+                            <hr>
+                            <h3>Загрузка *.torrent файлов с указанным PASSKEY</h3>
                             <label class="label">
                                 Каталог:
                                 <input id="dir_torrents" name="dir_torrents" class="inline-input" type="text" size="53"
-                                       title="Каталог, в который требуется сохранять торрент-файлы с изменённым Passkey."
+                                       title="Каталог, в который будут сохранены загруженные torrent-файлы с изменённым PASSKEY. Актуально при скачивании файлов для другого человека"
                                        value="<?= $cs('torrentDownload', 'folderReplace'); ?>"
                                 />
                             </label>

--- a/src/back/Config/ApiCredentials.php
+++ b/src/back/Config/ApiCredentials.php
@@ -26,14 +26,4 @@ final class ApiCredentials
             throw new RuntimeException('Отсутствуют ключи пользователя для доступа к API. Укажите их в настройках.');
         }
     }
-
-    /**
-     * @return array{api_key: string}
-     */
-    public function getApiKey(): array
-    {
-        $this->validate();
-
-        return ['api_key' => $this->apiKey];
-    }
 }

--- a/src/back/Config/ConfigServiceProvider.php
+++ b/src/back/Config/ConfigServiceProvider.php
@@ -334,6 +334,7 @@ final class ConfigServiceProvider extends AbstractServiceProvider
                 folder        : (string) $ini->read('download', 'savedir', Defaults::downloadPath),
                 subFolder     : (bool) $ini->read('download', 'savesubdir', 0),
                 addRetracker  : (bool) $ini->read('download', 'retracker', 0),
+                useApiProxy   : (bool) $ini->read('download', 'api_proxy', 0),
                 folderReplace : (string) $ini->read('curators', 'dir_torrents', Defaults::downloadPath),
                 replacePassKey: (string) $ini->read('curators', 'user_passkey'),
                 forRegularUser: (bool) $ini->read('curators', 'tor_for_user', 0)

--- a/src/back/Config/TorrentDownload.php
+++ b/src/back/Config/TorrentDownload.php
@@ -13,6 +13,7 @@ final class TorrentDownload
      * @param string $folder         путь хранения торрент-файлов
      * @param bool   $subFolder      создавать подкаталог
      * @param bool   $addRetracker   добавлять retracker.local
+     * @param bool   $useApiProxy    загружать файлы через API отчётов
      * @param string $folderReplace  путь хранения торрент-файлов с заменой ключа
      * @param string $replacePassKey ключ для замены
      * @param bool   $forRegularUser скачивать для не-хранителя
@@ -21,6 +22,7 @@ final class TorrentDownload
         public readonly string $folder,
         public readonly bool   $subFolder,
         public readonly bool   $addRetracker,
+        public readonly bool   $useApiProxy,
         public readonly string $folderReplace,
         public readonly string $replacePassKey,
         public readonly bool   $forRegularUser,

--- a/src/back/External/Construct/ForumConstructor.php
+++ b/src/back/External/Construct/ForumConstructor.php
@@ -6,9 +6,11 @@ namespace KeepersTeam\Webtlo\External\Construct;
 
 use GuzzleHttp\Client;
 use KeepersTeam\Webtlo\Config\ApiCredentials;
+use KeepersTeam\Webtlo\Config\ApiReportConnect;
 use KeepersTeam\Webtlo\Config\Defaults;
 use KeepersTeam\Webtlo\Config\ForumConnect;
 use KeepersTeam\Webtlo\Config\Proxy;
+use KeepersTeam\Webtlo\Config\TorrentDownload;
 use KeepersTeam\Webtlo\External\ForumClient;
 use KeepersTeam\Webtlo\External\Shared\RetryMiddleware;
 use KeepersTeam\Webtlo\WebTLO;
@@ -19,11 +21,13 @@ final class ForumConstructor
     use RetryMiddleware;
 
     public function __construct(
-        private readonly ApiCredentials  $auth,
-        private readonly ForumConnect    $connect,
-        private readonly LoggerInterface $logger,
-        private readonly Proxy           $proxy,
-        private readonly WebTLO          $webtlo,
+        private readonly ApiCredentials   $auth,
+        private readonly ApiReportConnect $apiConnect,
+        private readonly ForumConnect     $forumConnect,
+        private readonly TorrentDownload  $torrentDownload,
+        private readonly LoggerInterface  $logger,
+        private readonly Proxy            $proxy,
+        private readonly WebTLO           $webtlo,
     ) {}
 
     public function createRequestClient(): ForumClient
@@ -47,11 +51,16 @@ final class ForumConstructor
             'X-WebTLO'   => $this->webtlo->getSemanticVersion(),
         ];
 
-        $baseUrl = $this->connect->url;
+        // По умолчанию, создаём подключение к url форума.
+        $connectParams = $this->forumConnect;
+        // Если выбрана опция в настройках, то подключаемся к url API
+        if ($this->torrentDownload->useApiProxy) {
+            $connectParams = $this->apiConnect;
+        }
 
-        $proxyConfig = $this->connect->useProxy ? $this->proxy->getOptions() : [];
-
-        $timeout = $this->connect->timeout;
+        $baseUrl     = $connectParams->url;
+        $timeout     = $connectParams->timeout;
+        $proxyConfig = $connectParams->useProxy ? $this->proxy->getOptions() : [];
 
         $clientProperties = [
             'base_uri'        => $baseUrl,
@@ -68,7 +77,7 @@ final class ForumConstructor
         $client = new Client(config: $clientProperties);
 
         $log = ['base' => $baseUrl];
-        if ($this->connect->useProxy) {
+        if ($connectParams->useProxy) {
             $log['proxy'] = $this->proxy->log();
         }
         $this->logger->info('Подключение к Форуму (ForumClient)', $log);

--- a/src/back/Settings.php
+++ b/src/back/Settings.php
@@ -374,6 +374,7 @@ final class Settings
         }
         $ini->write('download', 'savesubdir', isset($cfg['savesubdir']) ? 1 : 0);
         $ini->write('download', 'retracker', isset($cfg['retracker']) ? 1 : 0);
+        $ini->write('download', 'api_proxy', isset($cfg['download_api_proxy']) ? 1 : 0);
     }
 
     /**


### PR DESCRIPTION
- Секция настроек "Скачивание торрент-файлов" обновлена, изменён порядок опций, добавлены подсказки.
- Добавлена новая опция "загружать файлы через API отчётов" в секцию "Скачивание торрент-файлов -> Откуда загружать *.torrent-файлы" (выключено по умолчанию). Включение данной опции позволит скачивать torrent-файлы через API отчётов ВМЕСТО форума. Полезно в случаях когда для вас форум недоступен, а API доступно.
<img width="737" height="190" alt="image" src="https://github.com/user-attachments/assets/798f1b5c-a554-4663-9745-0fafb03c6576" />

