### PR TITLE
Добавлена возможность принудительно запускать раздачи в qBittorent

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -159,7 +159,8 @@ $cs = function(string $section, string $key, int|string $default = '') use ($con
                             <button type="button" class="tor_label torrent_action" value="set_label" title="Установить метку для выделенных раздач текущего подраздела в торрент-клиенте (удерживайте Ctrl для установки произвольной метки)">
                                 <i class="fa fa-tag" aria-hidden="true"></i>
                             </button>
-                            <button type="button" class="tor_start torrent_action" value="start" title="Запустить выделенные раздачи текущего подраздела в торрент-клиенте">
+                            <button type="button" class="tor_start torrent_action" value="start"
+                                    title="Запустить выделенные раздачи текущего подраздела в торрент-клиенте. &#10;Ctrl+Click выполнит `принудительный` запуск.">
                                 <i class="fa fa-play" aria-hidden="true"></i>
                             </button>
                             <button type="button" class="tor_stop torrent_action" value="stop" title="Приостановить выделенные раздачи текущего подраздела в торрент-клиенте">
@@ -177,7 +178,8 @@ $cs = function(string $section, string $key, int|string $default = '') use ($con
                             <select id="update_info_select" class="filter-select-menu">
                             </select>
                         </div>
-                        <button class="send_reports" name="send_reports" type="button" title="Отправить отчёты на форум">
+                        <button class="send_reports" name="send_reports" type="button"
+                                title="Отправить отчёты на форум. &#10;Ctrl+Click отправит `чистый` отчёт.">
                             <i class="fa fa-paper-plane-o" aria-hidden="true"></i> Отправить отчёты
                         </button>
                         <button id="control_torrents" name="control_torrents" type="button" title="Выполнить регулировку раздач в торрент-клиентах">
@@ -1080,7 +1082,8 @@ $cs = function(string $section, string $key, int|string $default = '') use ($con
                     <button type="button" disabled id="get_reports" title="Повторить построение выбранного отчёта">
                         <i class="fa fa-refresh" aria-hidden="true"></i>
                     </button>
-                    <button type="button" class="send_reports" name="send_reports" title="Отправить отчёты на форум">
+                    <button type="button" class="send_reports" name="send_reports"
+                            title="Отправить отчёты на форум. &#10;Ctrl+Click отправит `чистый` отчёт.">
                         <i class="fa fa-paper-plane-o" aria-hidden="true"></i> Отправить отчёты
                     </button>
                 </div>

--- a/public/scripts/jquery.topics.init.js
+++ b/public/scripts/jquery.topics.init.js
@@ -112,7 +112,7 @@ $(document).ready(function () {
             tor_clients : tor_clients,
             sel_client  : $('#filter_client_id').val(),
             topic_hashes: topic_hashes,
-            // Принудительный запуск раздач, только uTorrent и Transmission.
+            // Принудительный запуск раздач, только qBittorrent, uTorrent и Transmission.
             force_start: (action === 'start' && e.ctrlKey),
             remove_data: false,
         }

--- a/src/back/Action/TopicControl.php
+++ b/src/back/Action/TopicControl.php
@@ -187,7 +187,13 @@ final class TopicControl
                             topic    : $topic,
                             peerLimit: $peerLimit,
                             isSeeding: !$torrent->paused,
+                            isForced : $torrent->forced,
                         );
+                    }
+
+                    // Если решено ничего не делать, пропускаем раздачу.
+                    if ($desiredChange->doNothing()) {
+                        continue;
                     }
 
                     if ($desiredChange->isRandom()) {

--- a/src/back/Clients/Data/Torrent.php
+++ b/src/back/Clients/Data/Torrent.php
@@ -21,6 +21,7 @@ final class Torrent
      * @param int|float         $done         прогресс загрузки (1 = скачана, <1 - качается)
      * @param bool              $paused       остановлена ли раздача в клиенте
      * @param bool              $error        есть ошибка в клиенте
+     * @param bool              $forced       принудительно запущена
      * @param null|string       $trackerError текст ошибки трекера
      * @param null|string       $comment      текст комментария раздачи (содержит topicId)
      * @param null|string       $storagePath  путь хранения раздачи на диске
@@ -35,6 +36,7 @@ final class Torrent
         public readonly int|float         $done,
         public readonly bool              $paused,
         public readonly bool              $error = false,
+        public readonly bool              $forced = false,
         public readonly ?string           $trackerError = null,
         public readonly ?string           $comment = null,
         public readonly ?string           $storagePath = null,

--- a/src/back/Clients/Qbittorrent.php
+++ b/src/back/Clients/Qbittorrent.php
@@ -121,6 +121,7 @@ final class Qbittorrent implements ClientInterface
                 done        : $payload['done'],
                 paused      : (bool) $payload['paused'],
                 error       : (bool) $payload['error'],
+                forced      : (bool) $payload['forced'],
                 trackerError: $payload['tracker_error'] ?: null,
                 comment     : $payload['comment'] ?: null,
                 storagePath : $payload['storagePath'] ?? null
@@ -231,7 +232,14 @@ final class Qbittorrent implements ClientInterface
 
         $methodName = $this->getTorrentMethodName(method: 'start');
 
-        return $this->sendRequest(url: $methodName, params: $fields);
+        $startResult = $this->sendRequest(url: $methodName, params: $fields);
+
+        if ($forceStart) {
+            // Прокидываем отдельный признак "принудительного запуска".
+            $this->sendRequest(url: 'torrents/setForceStart', params: ['value' => 'true', ...$fields]);
+        }
+
+        return $startResult;
     }
 
     public function stopTorrents(array $torrentHashes): bool
@@ -538,6 +546,7 @@ final class Qbittorrent implements ClientInterface
                 'error'         => $torrentError,
                 'name'          => $torrent['name'],
                 'paused'        => $torrentPaused,
+                'forced'        => $torrent['force_start'] ?? false,
                 'time_added'    => $torrent['added_on'],
                 'total_size'    => $torrent['total_size'],
                 'client_hash'   => $clientHash,

--- a/src/back/Enum/DesiredStatusChange.php
+++ b/src/back/Enum/DesiredStatusChange.php
@@ -30,6 +30,11 @@ enum DesiredStatusChange
         };
     }
 
+    public function doNothing(): bool
+    {
+        return $this === self::Nothing;
+    }
+
     public function isRandom(): bool
     {
         return match ($this) {

--- a/src/back/Module/Control/PeerCalc.php
+++ b/src/back/Module/Control/PeerCalc.php
@@ -44,8 +44,13 @@ final class PeerCalc
     /**
      * Определить желаемое состояние раздачи в клиенте, в зависимости от текущих значений и настроек.
      */
-    public function determineDesiredState(TopicPeers $topic, int $peerLimit, bool $isSeeding): DesiredStatusChange
+    public function determineDesiredState(TopicPeers $topic, int $peerLimit, bool $isSeeding, bool $isForced): DesiredStatusChange
     {
+        // Если раздача запущена принудительно извне, ничего не делаем.
+        if ($isSeeding && $isForced) {
+            return DesiredStatusChange::Nothing;
+        }
+
         // Если у раздачи нет личей и выбрана опция "не сидировать без личей", то рандомно останавливаем раздачу.
         if ($isSeeding && self::shouldSkipSeeding(control: $this->config, topic: $topic)) {
             return DesiredStatusChange::RandomStop;

--- a/src/back/Module/Control/Unseeded.php
+++ b/src/back/Module/Control/Unseeded.php
@@ -81,7 +81,7 @@ final class Unseeded
         if ($this->isEnable()) {
             if ($this->startCounter > 0) {
                 $this->logger->info(
-                    '[Unseeded] Запущено {count} из {total} раздач, которые не сидировались как минимум {days} дней.',
+                    '[Unseeded] В клиентах запущено {count} из {total} раздач, которые не сидировались как минимум {days} дней.',
                     [
                         'count' => $this->startCounter,
                         'total' => $this->totalCount,


### PR DESCRIPTION
close #586

- В данные раздачи добавлен признак `forced`. Актуально только для `qBittorent`. В API других клиентов похожих данный найти не удалось.
- Регулировка. Если раздача имеет признак `forced`, то статус раздачи ИЗМЕНЯТСЯ НЕ БУДЕТ. Это значит, что однажды вручную принудительно запущенная в клиенте раздача - не может быть остановлена ТЛО автоматически никогда.
- В панель управления раздачами добавлена подсказка о возможности "принудительно запустить" раздачи в клиенте. Актуально для `qBittorent`, `uTorrent`, `Transmission`.
<img width="551" height="97" alt="image" src="https://github.com/user-attachments/assets/c9d3b867-0913-47cc-bc4e-a10df3603041" />
