### PR TITLE
Регулировка. Исправлено "моргание" статуса раздач

### DIFF
--- a/src/back/Action/TopicControl.php
+++ b/src/back/Action/TopicControl.php
@@ -13,6 +13,7 @@ use KeepersTeam\Webtlo\Config\TorrentClients;
 use KeepersTeam\Webtlo\Module\Control\ApiSearch;
 use KeepersTeam\Webtlo\Module\Control\DbSearch;
 use KeepersTeam\Webtlo\Module\Control\PeerCalc;
+use KeepersTeam\Webtlo\Module\Control\ResultCounter;
 use KeepersTeam\Webtlo\Module\Control\Unseeded;
 use KeepersTeam\Webtlo\Timers;
 use Psr\Log\LoggerInterface;
@@ -86,7 +87,7 @@ final class TopicControl
 
             // Получаем раздачи из него.
             $torrents = $this->getClientTorrents($client);
-            if ($torrents === null) {
+            if ($torrents === null || !$torrents->count()) {
                 continue;
             }
 
@@ -99,6 +100,8 @@ final class TopicControl
 
             // Счётчики применения фортуны при переключении состояния раздачи.
             $randomCounter = $randomProc = 0;
+
+            $records = [];
 
             $controlTopics = ['stop' => [], 'start' => []];
             foreach ($topicsHashes as $group => $hashes) {
@@ -130,6 +133,17 @@ final class TopicControl
 
                 Timers::start("subsection_$group");
 
+                // Лимит пиров для регулировки текущей группы раздач.
+                $peerLimit = $this->calc->calcLimit(
+                    clientControlPeers    : $clientControlPeers,
+                    subsectionControlPeers: $subControlPeers,
+                );
+
+                $logRecord = [
+                    'forumId'   => $group,
+                    'peerLimit' => $peerLimit,
+                ];
+
                 $forumUnseededTopics = [];
                 if ($this->unseeded->checkLimit()) {
                     $forumUnseededTopics = $this->api->getUnseededHashes(
@@ -138,27 +152,25 @@ final class TopicControl
                         limit: $configControl->maxUnseededCount,
                     );
 
+                    $logRecord['unseeded'] = count($forumUnseededTopics);
+
                     $this->unseeded->updateTotal(count: count($forumUnseededTopics));
                 }
-
-                // Лимит пиров для регулировки текущей группы раздач.
-                $peerLimit = $this->calc->calcLimit(
-                    clientControlPeers    : $clientControlPeers,
-                    subsectionControlPeers: $subControlPeers,
-                );
 
                 // Получаем данные о пирах искомых раздач и перебираем их.
                 try {
                     $topicsPeers = $this->api->getGroupTopicPeersIterator(group: $group, hashes: $hashes);
                 } catch (RuntimeException $e) {
                     $this->logger->warning('Обработка подраздела не удалась', [
-                        'forumId'  => $group,
-                        'error'    => $e->getMessage(),
-                        'execTime' => Timers::getExecTime("subsection_$group"),
+                        'forumId' => $group,
+                        'error'   => $e->getMessage(),
+                        'sec'     => Timers::getExecTime("subsection_$group"),
                     ]);
 
                     continue;
                 }
+
+                $counter = new ResultCounter();
 
                 foreach ($topicsPeers as $topic) {
                     // Проверяем наличие и статус раздачи в клиенте.
@@ -191,6 +203,9 @@ final class TopicControl
                         );
                     }
 
+                    // Записываем результат анализа раздачи.
+                    $counter->add(seeding: !$torrent->paused, targetStatus: $desiredChange);
+
                     // Если решено ничего не делать, пропускаем раздачу.
                     if ($desiredChange->doNothing()) {
                         continue;
@@ -217,16 +232,18 @@ final class TopicControl
                     unset($topic, $torrent);
                 }
 
-                $this->logger->debug('Обработка подраздела', [
-                    'forumId'   => $group,
-                    'count'     => count($hashes),
-                    'unseeded'  => count($forumUnseededTopics),
-                    'peerLimit' => $peerLimit,
-                    'execTime'  => Timers::getExecTime("subsection_$group"),
+                $this->logger->debug('Анализ подраздела', [
+                    ...$logRecord,
+                    ...$counter->getResults(),
+                    'sec' => Timers::getExecTime("subsection_$group"),
                 ]);
+
+                $records[] = $counter;
 
                 unset($group, $hashes, $topicsPeers);
             }
+
+            $this->logger->debug('Анализ торрент клиента', ResultCounter::summary(results: $records)->getResults());
 
             // Если сработал рандом, запишем в лог.
             if ($randomProc > 0) {

--- a/src/back/External/Data/TopicPeers.php
+++ b/src/back/External/Data/TopicPeers.php
@@ -23,4 +23,12 @@ final class TopicPeers
         public readonly int    $leechers,
         public readonly int    $keepers,
     ) {}
+
+    /**
+     * У раздачи есть сиды и нет личей. Частный случай.
+     */
+    public function noLeechers(): bool
+    {
+        return $this->leechers === 0 && $this->seeders > 1;
+    }
 }

--- a/src/back/Module/Control/PeerCalc.php
+++ b/src/back/Module/Control/PeerCalc.php
@@ -51,9 +51,11 @@ final class PeerCalc
             return DesiredStatusChange::Nothing;
         }
 
-        // Если у раздачи нет личей и выбрана опция "не сидировать без личей", то рандомно останавливаем раздачу.
-        if ($isSeeding && self::shouldSkipSeeding(control: $this->config, topic: $topic)) {
-            return DesiredStatusChange::RandomStop;
+        // Если выключена опция "запускать раздачи с нулём личей" и у раздачи нет личей, то раздача должна быть остановлена.
+        if (!$this->config->seedingWithoutLeechers && $topic->noLeechers()) {
+            return $isSeeding
+                ? DesiredStatusChange::RandomStop
+                : DesiredStatusChange::Nothing;
         }
 
         // Расчётное значение пиров раздачи.
@@ -139,13 +141,5 @@ final class PeerCalc
         $peerLimit = $interval->getCurrentIntervalPeerLimit($currentHour);
 
         return $this->peerLimit = $peerLimit ?? $this->config->peersLimit;
-    }
-
-    /**
-     * Определяет, следует ли остановить сидирование раздачи.
-     */
-    private static function shouldSkipSeeding(TopicControl $control, TopicPeers $topic): bool
-    {
-        return !$control->seedingWithoutLeechers && $topic->leechers === 0 && $topic->seeders > 1;
     }
 }

--- a/src/back/Module/Control/ResultCounter.php
+++ b/src/back/Module/Control/ResultCounter.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KeepersTeam\Webtlo\Module\Control;
+
+use KeepersTeam\Webtlo\Enum\DesiredStatusChange as TopicStatus;
+
+/**
+ * Счётчик изменений статуса раздач в клиенте в процессе регулировки.
+ */
+final class ResultCounter
+{
+    /**
+     * @param list<array{before: TopicStatus, after: TopicStatus}> $topics
+     */
+    public function __construct(private array $topics = []) {}
+
+    /**
+     * Добавить результат анализа раздачи в буфер.
+     */
+    public function add(bool $seeding, TopicStatus $targetStatus): void
+    {
+        $this->topics[] = [
+            'before' => $seeding ? TopicStatus::Start : TopicStatus::Stop,
+            'after'  => $targetStatus,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getResults(): array
+    {
+        if ($this->topics === []) {
+            return ['count' => 0];
+        }
+
+        // Разбиваем результаты на две группы.
+        $seeding = array_filter($this->topics, static fn($el) => $el['before'] === TopicStatus::Start);
+        $paused  = array_filter($this->topics, static fn($el) => $el['before'] === TopicStatus::Stop);
+
+        $result = [
+            'count'   => count($this->topics),
+            'seeding' => count($seeding),
+            'paused'  => count($paused),
+        ];
+
+        if ($seeding !== []) {
+            // Группировка по имени варианта enum.
+            $seedingCounts = array_count_values(
+                array_map(
+                    static fn(TopicStatus $e) => $e->name,
+                    array_column($seeding, 'after')
+                )
+            );
+
+            // Сортируем по убыванию количества.
+            arsort($seedingCounts);
+            $result['seedingChange'] = $seedingCounts;
+        }
+
+        if ($paused !== []) {
+            // Группировка по имени варианта enum.
+            $pausedCounts = array_count_values(
+                array_map(
+                    static fn(TopicStatus $e) => $e->name,
+                    array_column($paused, 'after')
+                )
+            );
+
+            // Сортируем по убыванию количества.
+            arsort($pausedCounts);
+            $result['pausedChange'] = $pausedCounts;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param self[] $results
+     */
+    public static function summary(array $results): self
+    {
+        $topics = array_column($results, 'topics');
+
+        return new self(topics: array_merge(...$topics));
+    }
+}


### PR DESCRIPTION
В случае отключения опции "запускать раздачи с 0 (нулём) личей", раздачи с нулём личей "моргали".
Регулировка №1 случайно выключала такую раздачу, если она запущена.
Регулировка №2 включала раздачу, т.к. она находилась в "поясе" желаемых пиров + рандом.
Регулировка №3 снова выключала раздачу, т.к. личей всё ещё ноль
Зацикливаем.

В итоге большой пласт раздач "моргал" то включаясь, то выключаясь.

Теперь, если опция выключена, то "желаемый" статус раздач -> "выключена".
Если раздача включена -> оставить случайно.
Если выключена - ничего не делать.

---
Попутно записи дебаг журнала теперь более подробные и содержат исходный и желаемый статус раздача по каждому регулируемому подразделу и клиенту.