### PR TITLE
UI. Оптимизация присвоения меток из панели

### DIFF
--- a/public/php/exec_actions_topics.php
+++ b/public/php/exec_actions_topics.php
@@ -7,6 +7,7 @@ use KeepersTeam\Webtlo\App;
 use KeepersTeam\Webtlo\Helper;
 use KeepersTeam\Webtlo\Module\Action\ClientAction;
 use KeepersTeam\Webtlo\Module\Action\ClientApplyOptions;
+use KeepersTeam\Webtlo\TopicList\ListingType;
 
 // Подключаем контейнер.
 $app = App::create();
@@ -34,9 +35,12 @@ try {
 
     // Дополнительные параметры.
     $actionOptions = new ClientApplyOptions(
-        label      : (string) ($request['label'] ?? ''),
-        forceStart : (bool) ($request['force_start'] ?? 0),
-        removeFiles : (bool) ($request['remove_data'] ?? 0),
+        label      : isset($request['label']) ? (string) $request['label'] : null,
+        forceStart : (bool) ($request['force_start'] ?? false),
+        removeFiles: (bool) ($request['remove_data'] ?? false),
+        listingType: ListingType::tryFrom(
+            (int) ($request['listingType'] ?? -999),
+        )
     );
 
     parse_str($request['topic_hashes'], $topicHashes);

--- a/public/scripts/jquery.topics.func.js
+++ b/public/scripts/jquery.topics.func.js
@@ -110,22 +110,6 @@ function getCurrentSubsection() {
     return +$('#main-subsections').val();
 }
 
-/**
- * Метка для раздач, в зависимости от подраздела.
- *
- * @param {number} subsection
- * @returns {string}
- */
-function getLabelBySubsection(subsection) {
-    if (subsection > 0) {
-        const forumData = $(`#list-forums [value=${subsection}]`).data();
-
-        return '' + forumData.label;
-    }
-
-    return '';
-}
-
 // получение отфильтрованных раздач из базы
 function getFilteredTopics() {
     // Ставим в "очередь" поиск раздач при выполнении тяжелых запросов.

--- a/public/scripts/jquery.topics.init.js
+++ b/public/scripts/jquery.topics.init.js
@@ -97,18 +97,14 @@ $(document).ready(function () {
         }
 
         // Текущий выбранный "разворот раздач"/ подраздел.
-        const subsection = getCurrentSubsection();
+        const listingType = getCurrentSubsection();
 
         const action = $(this).val();
 
-        // Разворот, при котором можно установить произвольную метку.
-        const labelSubsections = [0, -3, -4, -5];
-        const allowCustomLabel = e.ctrlKey || ~$.inArray(subsection, labelSubsections);
-
         let params = {
             action      : action,
-            subsection  : subsection,
-            label       : getLabelBySubsection(subsection),
+            listingType : listingType,
+            label       : null,
             tor_clients : tor_clients,
             sel_client  : $('#filter_client_id').val(),
             topic_hashes: topic_hashes,
@@ -156,8 +152,8 @@ $(document).ready(function () {
         }
 
         // Присвоение метки.
-        if (action === 'set_label' && allowCustomLabel) {
-            dialog.html('<label>Установить метку: <input id="any_label" size="27" />');
+        if (action === 'set_label' && e.ctrlKey) {
+            dialog.html('<label>Установить метку: <input type="text" id="any_label" size="27" placeholder="<пустая строка>"/></label>');
             dialog.dialog({
                 buttons  : [
                     {

--- a/src/back/Action/ClientApplyAction.php
+++ b/src/back/Action/ClientApplyAction.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace KeepersTeam\Webtlo\Action;
 
 use KeepersTeam\Webtlo\Clients\ClientFactory;
+use KeepersTeam\Webtlo\Config\SubForums;
 use KeepersTeam\Webtlo\Module\Action\ClientAction;
 use KeepersTeam\Webtlo\Module\Action\ClientApplyOptions;
 use KeepersTeam\Webtlo\Storage\Table\Torrents;
@@ -19,6 +20,7 @@ final class ClientApplyAction
     public function __construct(
         private readonly LoggerInterface $logger,
         private readonly ClientFactory   $clientFactory,
+        private readonly SubForums       $subForums,
         private readonly Torrents        $tableTorrents,
     ) {}
 
@@ -34,14 +36,14 @@ final class ClientApplyAction
         $this->logger->info("Начато выполнение действия '$action->value' для выбранных раздач...");
         $this->logger->debug('Получение хэшей раздач с привязкой к торрент-клиенту...');
 
-        $torrentHashesByClient = $this->tableTorrents->getGroupedByClientTopics(hashes: $hashes);
-        if (!count($torrentHashesByClient)) {
-            throw new RuntimeException('Не получены данные о выбранных раздачах');
+        $groupByClient = $this->tableTorrents->getGroupedTopics(hashes: $hashes);
+        if (!count($groupByClient)) {
+            throw new RuntimeException('Не удалось найти данные о выбранных раздачах');
         }
 
         $this->logger->info(
             'Количество затрагиваемых торрент-клиентов: {client}',
-            ['client' => count($torrentHashesByClient)]
+            ['client' => count($groupByClient)]
         );
 
         if ($action === ClientAction::Remove && $selectedClient === 0) {
@@ -57,13 +59,7 @@ final class ClientApplyAction
             );
         }
 
-        foreach ($torrentHashesByClient as $clientId => $torrentHashes) {
-            if (empty($torrentHashes)) {
-                continue;
-            }
-
-            $clientId = (int) $clientId;
-
+        foreach ($groupByClient as $clientId => $groupBySubForum) {
             // Пропускаем раздачи в других клиентах, если задан фильтр.
             if ($selectedClient > 0 && $selectedClient !== $clientId) {
                 continue;
@@ -79,56 +75,96 @@ final class ClientApplyAction
 
             $logRecord = ['tag' => $client->getClientTag(), 'action' => $action->value];
 
-            $response = false;
-            switch ($action) {
-                case ClientAction::SetLabel:
-                    $response = $client->setLabel(torrentHashes: $torrentHashes, label: $params->label);
+            foreach ($groupBySubForum as $subForumId => $torrentHashes) {
+                if (empty($torrentHashes)) {
+                    continue;
+                }
 
-                    break;
-                case ClientAction::Stop:
-                    $response = $client->stopTorrents(torrentHashes: $torrentHashes);
+                $response = false;
+                switch ($action) {
+                    case ClientAction::SetLabel:
+                        // Если метка не задана в запросе, пробуем найти в настройках по ид подраздела.
+                        $label = $this->findLabel(params: $params, subForumId: $subForumId);
 
-                    // Отмечаем в БД изменение статуса раздач.
-                    if ($response !== false) {
-                        $this->tableTorrents->setTorrentsStatusByHashes(hashes: $torrentHashes, paused: true);
-                    }
+                        $logRecord['forumId'] = $subForumId;
+                        $logRecord['label']   = $label;
 
-                    break;
-                case ClientAction::Start:
-                    $response = $client->startTorrents(torrentHashes: $torrentHashes, forceStart: $params->forceStart);
+                        $response = $client->setLabel(torrentHashes: $torrentHashes, label: $label);
 
-                    // Отмечаем в БД изменение статуса раздач.
-                    if ($response !== false) {
-                        $this->tableTorrents->setTorrentsStatusByHashes(hashes: $torrentHashes, paused: false);
-                    }
+                        break;
+                    case ClientAction::Stop:
+                        $response = $client->stopTorrents(torrentHashes: $torrentHashes);
 
-                    break;
-                case ClientAction::Remove:
-                    $response = $client->removeTorrents(torrentHashes: $torrentHashes, deleteFiles: $params->removeFiles);
+                        // Отмечаем в БД изменение статуса раздач.
+                        if ($response !== false) {
+                            $this->tableTorrents->setTorrentsStatusByHashes(
+                                hashes: $torrentHashes,
+                                paused: true
+                            );
+                        }
 
-                    // Отмечаем в БД удаление раздач.
-                    if ($response !== false) {
-                        $this->tableTorrents->deleteTorrentsByHashes(hashes: $torrentHashes);
-                    }
+                        break;
+                    case ClientAction::Start:
+                        $response = $client->startTorrents(
+                            torrentHashes: $torrentHashes,
+                            forceStart   : $params->forceStart
+                        );
 
-                    break;
+                        // Отмечаем в БД изменение статуса раздач.
+                        if ($response !== false) {
+                            $this->tableTorrents->setTorrentsStatusByHashes(
+                                hashes: $torrentHashes,
+                                paused: false
+                            );
+                        }
+
+                        break;
+                    case ClientAction::Remove:
+                        $response = $client->removeTorrents(
+                            torrentHashes: $torrentHashes,
+                            deleteFiles  : $params->removeFiles
+                        );
+
+                        // Отмечаем в БД удаление раздач.
+                        if ($response !== false) {
+                            $this->tableTorrents->deleteTorrentsByHashes(hashes: $torrentHashes);
+                        }
+
+                        break;
+                }
+
+                if ($response === false) {
+                    $this->logger->warning(
+                        "Возникли проблемы при выполнении действия '{action}' для торрент-клиента '{tag}'",
+                        $logRecord
+                    );
+                } else {
+                    $this->logger->info(
+                        "Действие '{action}' для торрент-клиента '{tag}' выполнено ({count})",
+                        [...$logRecord, 'count' => count($torrentHashes)]
+                    );
+                }
             }
-
-            if ($response === false) {
-                $this->logger->warning(
-                    "Возникли проблемы при выполнении действия '{action}' для торрент-клиента '{tag}'",
-                    $logRecord
-                );
-            } else {
-                $this->logger->info(
-                    "Действие '{action}' для торрент-клиента '{tag}' выполнено ({count})",
-                    [...$logRecord, 'count' => count($torrentHashes)]
-                );
-            }
-            unset($clientId, $torrentHashes);
         }
 
         $this->logger->info("Выполнение действия '$action->value' завершено.");
         $this->logger->info('-- DONE --');
+    }
+
+    private function findLabel(ClientApplyOptions $params, int $subForumId): string
+    {
+        // Метка есть в запросе, значит её и используем.
+        if ($params->label !== null) {
+            return $params->label;
+        }
+
+        // Текущий разворот подразумевает массовое присвоение меток.
+        if ($params->listingType === null || $params->listingType->allowMassLabelSet()) {
+            // Пробуем найти метку по подразделу.
+            return $this->subForums->getSubForum(subForumId: $subForumId)->label ?? '';
+        }
+
+        // Пробуем присвоить метку по умолчанию или пустую.
+        return $params->listingType->getDefaultLabel();
     }
 }

--- a/src/back/Module/Action/ClientApplyOptions.php
+++ b/src/back/Module/Action/ClientApplyOptions.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace KeepersTeam\Webtlo\Module\Action;
 
+use KeepersTeam\Webtlo\TopicList\ListingType;
+
 final class ClientApplyOptions
 {
     public function __construct(
-        public readonly string $label,
-        public readonly bool   $forceStart,
-        public readonly bool   $removeFiles
+        public readonly ?string      $label,
+        public readonly bool         $forceStart,
+        public readonly bool         $removeFiles,
+        public readonly ?ListingType $listingType,
     ) {}
 }

--- a/src/back/Storage/Table/Torrents.php
+++ b/src/back/Storage/Table/Torrents.php
@@ -46,38 +46,33 @@ final class Torrents
     }
 
     /**
-     * Найти список раздач, сгруппировав их по ид клиента.
+     * Найти список раздач, сгруппировав их по ид клиента и ид подраздела.
      *
-     * @param string[]     $hashes
-     * @param positive-int $chunkSize
+     * @param string[] $hashes
      *
-     * @return array<int, string[]>
+     * @return array<int, array<int, string[]>>
      */
-    public function getGroupedByClientTopics(array $hashes, int $chunkSize = 499): array
+    public function getGroupedTopics(array $hashes): array
     {
         $result = [];
 
-        $hashes = array_chunk(array_unique($hashes), $chunkSize);
+        $hashes = array_chunk(array_unique($hashes), 500);
 
         foreach ($hashes as $chunk) {
             $search = KeysObject::create($chunk);
+            $query  = "
+                SELECT tr.client_id, tp.forum_id, tr.info_hash
+                FROM Torrents AS tr
+                    LEFT JOIN Topics AS tp ON tp.info_hash = tr.info_hash
+                WHERE tr.info_hash IN ($search->keys)
+            ";
 
-            $stm = $this->con->executeStatement(
-                "
-                    SELECT client_id, info_hash FROM Torrents
-                    WHERE info_hash IN ($search->keys)
-                ",
-                $search->values,
-            );
+            $topics = $this->con->query($query, $search->values);
+            foreach ($topics as $topic) {
+                $clientId = (int) $topic['client_id'];
+                $forumId  = (int) $topic['forum_id'];
 
-            $topics = $stm->fetchAll(PDO::FETCH_GROUP | PDO::FETCH_COLUMN);
-
-            foreach ($topics as $clientId => $clientHashes) {
-                $clientId = (int) $clientId;
-
-                $result[$clientId] = isset($result[$clientId])
-                    ? array_merge($result[$clientId], $clientHashes)
-                    : $clientHashes;
+                $result[$clientId][$forumId][] = $topic['info_hash'];
             }
         }
 

--- a/src/back/TopicList/ListingType.php
+++ b/src/back/TopicList/ListingType.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KeepersTeam\Webtlo\TopicList;
+
+/**
+ * Тип выборки раздач (разворот).
+ *
+ * @see index.php #main-subsections
+ */
+enum ListingType: int
+{
+    /**
+     * Раздачи из всех хранимых подразделов.
+     */
+    case AllKept = -3;
+
+    /**
+     * Раздачи с высоким приоритетом хранения.
+     */
+    case HighPriority = -5;
+
+    /**
+     * Раздачи из «чёрного списка».
+     */
+    case BlackListed = -2;
+
+    /**
+     * Хранимые дублирующиеся раздачи.
+     */
+    case Duplicated = -4;
+
+    /**
+     * Хранимые раздачи по спискам
+     */
+    case SelfKeep = -6;
+
+    /**
+     * Хранимые раздачи из других подразделов.
+     */
+    case OtherSubForums = 0;
+
+    /**
+     * Хранимые раздачи незарегистрированные на трекере.
+     */
+    case Unregistered = -1;
+
+    public function getDefaultLabel(): string
+    {
+        return match ($this) {
+            self::OtherSubForums,
+            self::Unregistered,
+            self::Duplicated => '__' . strtoupper($this->name) . '__',
+            default          => '',
+        };
+    }
+
+    /**
+     * В зависимости от типа разворота, можно попробовать выставлять метку массово.
+     */
+    public function allowMassLabelSet(): bool
+    {
+        return match ($this) {
+            self::AllKept,
+            self::HighPriority,
+            self::SelfKeep => true,
+            default        => false,
+        };
+    }
+}


### PR DESCRIPTION


1. Кнопка "присвоить метку" теперь работает чуть более очевидно (я надеюсь).
 - одиночное нажатие присваивает "определённую метку" выбранным раздачам без вопросов
 - ctrl + нажатие отображает окно для ввода "желаемой" метки (или пустоты) и присваивает её выбранным раздачам
 - "пустота" (пустая строка" большинством клиентов рассматривается как "снятие метки"

2. "Определённая метка" - это 
- если "разворот" по конкретному подразделу - метка из настроек подраздела
- если "разворот" с набором раздач из многих подраздлелов (все хранимые, высокий приоритет, хранимые по спискам) - раздачи будут разделены на группы по подразделам и метка будет взята из настроек каждого из них.
- если "разворот" содержит раздачи "особых случаев" (прочие, разреги, дубликаты) - метка будет особая, например `__UNREGISTERED__` (close #182)

Теперь можно:
- выбрать ВСЕ хранимые раздачи и выдать (или перезаписать) метку из настроек подраздела
- выбрать "особые" раздачи и выдать им уникальную метку, чтобы не спутать их с обычными метками от подразделов или каким-то другими
- снять метку (отправить пустую строку) а потом выдать иную желаемую метку.


> [!NOTE]
> Для qBittorent всё ещё существует проблема с hash_v2, см #236. Таким раздачам выдать метку из панели не выйдет.