### PR TITLE
Клиенты. Все операции с раздачами разбиты на части

### DIFF
--- a/src/back/Action/TopicControl.php
+++ b/src/back/Action/TopicControl.php
@@ -266,23 +266,17 @@ final class TopicControl
 
             // Запускаем раздачи.
             if (count($controlTopics['start'])) {
-                // TODO перекинуть задачу разбиения хешей на чанки торрент-клиентам.
-                foreach (array_chunk($controlTopics['start'], 100) as $hashes) {
-                    $response = $client->startTorrents(torrentHashes: $hashes);
-                    if ($response === false) {
-                        $this->logger->error('Возникли проблемы при отправке запроса на запуск раздач.');
-                    }
+                $response = $client->startTorrents(torrentHashes: $controlTopics['start']);
+                if ($response === false) {
+                    $this->logger->error('Возникли проблемы при отправке запроса на запуск раздач.');
                 }
             }
 
             // Останавливаем раздачи.
             if (count($controlTopics['stop'])) {
-                // TODO перекинуть задачу разбиения хешей на чанки торрент-клиентам.
-                foreach (array_chunk($controlTopics['stop'], 100) as $hashes) {
-                    $response = $client->stopTorrents(torrentHashes: $hashes);
-                    if ($response === false) {
-                        $this->logger->error('Возникли проблемы при отправке запроса на остановку раздач.');
-                    }
+                $response = $client->stopTorrents(torrentHashes: $controlTopics['stop']);
+                if ($response === false) {
+                    $this->logger->error('Возникли проблемы при отправке запроса на остановку раздач.');
                 }
             }
 

--- a/src/back/Clients/Deluge.php
+++ b/src/back/Clients/Deluge.php
@@ -17,11 +17,12 @@ use RuntimeException;
 use Throwable;
 
 /**
- * Class Deluge
- * Supported by Deluge 2.1.1 [ plugins WebUi 0.2 and Label 0.3 ] and later.
+ * Class Deluge.
  *
- * https://deluge.readthedocs.io/en/latest/devguide/how-to/curl-jsonrpc.html
- * https://github.com/kaysond/deluge-php/blob/master/deluge.class.php
+ * Supported by Deluge 2.1.1 [plugins WebUi 0.2 and Label 0.3] and later.
+ *
+ * @see https://deluge.readthedocs.io/en/latest/devguide/how-to/curl-jsonrpc.html
+ * @see https://github.com/kaysond/deluge-php/blob/master/deluge.class.php
  */
 final class Deluge implements ClientInterface
 {
@@ -30,6 +31,8 @@ final class Deluge implements ClientInterface
     use Traits\CheckDomain;
     use Traits\ClientTag;
     use Traits\RetryMiddleware;
+
+    public const ACTION_CHUNK_SIZE = 500;
 
     /** Счетчик запросов API. */
     private int $counter = 1;
@@ -117,7 +120,7 @@ final class Deluge implements ClientInterface
             unset($torrentHash, $torrent, $torrentError, $trackerError, $progress);
         }
 
-        return new Torrents($torrents);
+        return new Torrents(torrents: $torrents);
     }
 
     public function addTorrent(string $torrentFilePath, string $savePath = '', string $label = ''): bool
@@ -145,6 +148,9 @@ final class Deluge implements ClientInterface
         return $this->sendRequest(method: 'core.add_torrent_file', params: $fields);
     }
 
+    /**
+     * Метка присваивается по одной раздаче. Разделение не нужно.
+     */
     public function setLabel(array $torrentHashes, string $label = ''): bool
     {
         if (!empty($label)) {
@@ -177,20 +183,22 @@ final class Deluge implements ClientInterface
         return $result;
     }
 
+    /**
+     * Клиент не поддерживает принудительный запуск раздач.
+     */
     public function startTorrents(array $torrentHashes, bool $forceStart = false): bool
     {
-        $params = $this->prepareHashes($torrentHashes);
-
-        return $this->sendRequest('core.resume_torrent', $params);
+        return $this->actionTorrents(method: 'core.resume_torrent', hashes: $torrentHashes);
     }
 
     public function stopTorrents(array $torrentHashes): bool
     {
-        $params = $this->prepareHashes($torrentHashes);
-
-        return $this->sendRequest('core.pause_torrent', $params);
+        return $this->actionTorrents(method: 'core.pause_torrent', hashes: $torrentHashes);
     }
 
+    /**
+     * Удаление по одной раздаче. Разделение не нужно.
+     */
     public function removeTorrents(array $torrentHashes, bool $deleteFiles = false): bool
     {
         $result = true;
@@ -211,9 +219,7 @@ final class Deluge implements ClientInterface
 
     public function recheckTorrents(array $torrentHashes): bool
     {
-        $params = $this->prepareHashes($torrentHashes);
-
-        return $this->sendRequest(method: 'core.force_recheck', params: $params);
+        return $this->actionTorrents(method: 'core.force_recheck', hashes: $torrentHashes);
     }
 
     /**
@@ -224,7 +230,7 @@ final class Deluge implements ClientInterface
         if (!$this->authenticated) {
             try {
                 // Авторизуемся в клиенте. Логин всегда deluge.
-                $this->request('auth.login', [$this->options->credentials->password ?? '']);
+                $this->request(method: 'auth.login', params: [$this->options->credentials->password ?? '']);
 
                 // Проверяем успешность и наличие куки авторизации.
                 if ($this->jar->count() === 0) {
@@ -237,11 +243,11 @@ final class Deluge implements ClientInterface
                 }
 
                 // Пробуем подключится к клиенту.
-                $this->authenticated = $this->sendRequest('web.connected');
+                $this->authenticated = $this->sendRequest(method: 'web.connected');
 
                 // Если подключение не удалось - начинаем шаманство.
                 if (!$this->authenticated) {
-                    $hosts = $this->makeRequest('web.get_hosts');
+                    $hosts = $this->makeRequest(method: 'web.get_hosts');
 
                     $webUiHost = $hosts[0][0] ?? null;
                     if ($webUiHost === null) {
@@ -250,7 +256,7 @@ final class Deluge implements ClientInterface
                         return false;
                     }
 
-                    $hostStatus = $this->makeRequest('web.get_host_status', [$webUiHost]);
+                    $hostStatus = $this->makeRequest(method: 'web.get_host_status', params: [$webUiHost]);
                     if (in_array('Offline', $hostStatus)) {
                         $this->logger->error('WebUI host is offline', $hostStatus);
                     } elseif (in_array('Online', $hostStatus)) {
@@ -273,6 +279,7 @@ final class Deluge implements ClientInterface
     }
 
     /**
+     * @param literal-string    $method
      * @param array<int, mixed> $params
      *
      * @throws GuzzleException
@@ -289,6 +296,7 @@ final class Deluge implements ClientInterface
     }
 
     /**
+     * @param literal-string    $method
      * @param array<int, mixed> $params
      *
      * @return array<int|string, mixed>
@@ -315,6 +323,7 @@ final class Deluge implements ClientInterface
     }
 
     /**
+     * @param literal-string    $method
      * @param array<int, mixed> $params
      */
     private function sendRequest(string $method, array $params = []): bool
@@ -331,13 +340,32 @@ final class Deluge implements ClientInterface
     }
 
     /**
-     * @param string[] $torrentHashes
+     * Выполняет массовое действие над торрентами с разбивкой.
      *
-     * @return string[][]
+     * @param literal-string $method
+     * @param string[]       $hashes
+     *
+     * @return bool true, если все части успешно обработаны, иначе false
      */
-    private function prepareHashes(array $torrentHashes): array
+    private function actionTorrents(string $method, array $hashes): bool
     {
-        return [array_map('strtolower', $torrentHashes)];
+        if ($hashes === []) {
+            return true;
+        }
+
+        $result = true;
+        foreach (array_chunk($hashes, self::ACTION_CHUNK_SIZE) as $chunk) {
+            $response = $this->sendRequest(
+                method: $method,
+                params: self::prepareHashes(hashes: $chunk),
+            );
+
+            if ($response === false) {
+                $result = false;
+            }
+        }
+
+        return $result;
     }
 
     private function checkLabelExists(string $labelName): bool
@@ -365,5 +393,15 @@ final class Deluge implements ClientInterface
     private function enablePlugin(string $pluginName): bool
     {
         return $this->sendRequest(method: 'core.enable_plugin', params: [$pluginName]);
+    }
+
+    /**
+     * @param string[] $hashes
+     *
+     * @return string[][]
+     */
+    private static function prepareHashes(array $hashes): array
+    {
+        return [array_map('strtolower', $hashes)];
     }
 }

--- a/src/back/Clients/Flood.php
+++ b/src/back/Clients/Flood.php
@@ -18,10 +18,11 @@ use RuntimeException;
 use Throwable;
 
 /**
- * Class Flood
+ * Class Flood.
+ *
  * Supported by flood by jesec API.
  *
- * https://flood-api.netlify.app
+ * @see https://flood-api.netlify.app
  */
 final class Flood implements ClientInterface
 {
@@ -30,6 +31,8 @@ final class Flood implements ClientInterface
     use Traits\CheckDomain;
     use Traits\ClientTag;
     use Traits\RetryMiddleware;
+
+    public const ACTION_CHUNK_SIZE = 500;
 
     /** @var string[] */
     private const trackerErrorStates = [
@@ -77,7 +80,7 @@ final class Flood implements ClientInterface
             $torrentHash   = strtoupper($torrent['hash']);
             $torrentPaused = in_array('stopped', $torrent['status']);
 
-            [$torrentError, $errorMessage] = self::checkTorrentError($torrent);
+            [$torrentError, $errorMessage] = self::checkTorrentError(torrent: $torrent);
 
             $torrents[$torrentHash] = new Torrent(
                 topicHash   : $torrentHash,
@@ -97,7 +100,7 @@ final class Flood implements ClientInterface
             unset($torrent, $torrentHash, $torrentPaused, $torrentError, $errorMessage);
         }
 
-        return new Torrents($torrents);
+        return new Torrents(torrents: $torrents);
     }
 
     public function addTorrent(string $torrentFilePath, string $savePath = '', string $label = ''): bool
@@ -109,7 +112,7 @@ final class Flood implements ClientInterface
             return false;
         }
 
-        return $this->addTorrentContent($content, $savePath, $label);
+        return $this->addTorrentContent(content: $content, savePath: $savePath, label: $label);
     }
 
     public function addTorrentContent(string $content, string $savePath = '', string $label = ''): bool
@@ -120,58 +123,44 @@ final class Flood implements ClientInterface
             'start'       => true,
         ];
         if (!empty($label)) {
-            $fields['tags'] = [$this->prepareLabel($label)];
+            $fields['tags'] = [$this->prepareLabel(label: $label)];
         }
 
-        return $this->sendRequest('torrents/add-files', 'POST', $fields);
+        return $this->sendRequest(uri: 'torrents/add-files', method: 'POST', params: $fields);
     }
 
     /**
      * Присвоение пустой метки (удаление метки) - не работает для qBittorrent.
      *
-     * https://github.com/jesec/flood/issues/605
+     * @see https://github.com/jesec/flood/issues/605
      */
     public function setLabel(array $torrentHashes, string $label = ''): bool
     {
-        $fields = [
-            'hashes' => $torrentHashes,
-            'tags'   => [$this->prepareLabel($label)],
-        ];
+        $extra = ['tags' => [$this->prepareLabel($label)]];
 
-        return $this->sendRequest('torrents/tags', 'PATCH', $fields);
+        return $this->actionTorrents(uri: 'torrents/tags', method: 'PATCH', hashes: $torrentHashes, extra: $extra);
     }
 
     public function startTorrents(array $torrentHashes, bool $forceStart = false): bool
     {
-        $fields = ['hashes' => $torrentHashes];
-
-        return $this->sendRequest('torrents/start', 'POST', $fields);
+        return $this->actionTorrents(uri: 'torrents/start', method: 'POST', hashes: $torrentHashes);
     }
 
     public function stopTorrents(array $torrentHashes): bool
     {
-        $fields = ['hashes' => $torrentHashes];
-
-        return $this->sendRequest('torrents/stop', 'POST', $fields);
+        return $this->actionTorrents(uri: 'torrents/stop', method: 'POST', hashes: $torrentHashes);
     }
 
     public function removeTorrents(array $torrentHashes, bool $deleteFiles = false): bool
     {
-        $deleteFiles = $deleteFiles ? 'true' : 'false';
+        $extra = ['deleteData' => $deleteFiles ? 'true' : 'false'];
 
-        $fields = [
-            'hashes'     => $torrentHashes,
-            'deleteData' => $deleteFiles,
-        ];
-
-        return $this->sendRequest('torrents/delete', 'POST', $fields);
+        return $this->actionTorrents(uri: 'torrents/delete', method: 'POST', hashes: $torrentHashes, extra: $extra);
     }
 
     public function recheckTorrents(array $torrentHashes): bool
     {
-        $fields = ['hashes' => $torrentHashes];
-
-        return $this->sendRequest('torrents/check-hash', 'POST', $fields);
+        return $this->actionTorrents(uri: 'torrents/check-hash', method: 'POST', hashes: $torrentHashes);
     }
 
     /**
@@ -187,7 +176,7 @@ final class Flood implements ClientInterface
                     return false;
                 }
 
-                $response = $this->client->post('auth/authenticate', [
+                $response = $this->client->post(uri: 'auth/authenticate', options: [
                     'form_params' => [
                         'username' => $this->options->credentials->username,
                         'password' => $this->options->credentials->password,
@@ -225,6 +214,8 @@ final class Flood implements ClientInterface
     }
 
     /**
+     * @param literal-string       $uri
+     * @param literal-string       $method
      * @param array<string, mixed> $params
      *
      * @throws GuzzleException
@@ -240,6 +231,8 @@ final class Flood implements ClientInterface
     }
 
     /**
+     * @param literal-string       $uri
+     * @param literal-string       $method
      * @param array<string, mixed> $params
      *
      * @return array<string, mixed>
@@ -258,6 +251,8 @@ final class Flood implements ClientInterface
     }
 
     /**
+     * @param literal-string       $uri
+     * @param literal-string       $method
      * @param array<string, mixed> $params
      */
     private function sendRequest(string $uri, string $method = 'GET', array $params = []): bool
@@ -286,6 +281,37 @@ final class Flood implements ClientInterface
         }
 
         return false;
+    }
+
+    /**
+     * Выполняет массовое действие над торрентами с разбивкой.
+     *
+     * @param literal-string       $uri
+     * @param literal-string       $method
+     * @param string[]             $hashes
+     * @param array<string, mixed> $extra  Дополнительные поля, которые будут добавлены в тело запроса
+     *
+     * @return bool true, если все части успешно обработаны, иначе false
+     */
+    private function actionTorrents(string $uri, string $method, array $hashes, array $extra = []): bool
+    {
+        if ($hashes === []) {
+            return true;
+        }
+
+        $result = true;
+        foreach (array_chunk($hashes, self::ACTION_CHUNK_SIZE) as $chunk) {
+            $response = $this->sendRequest(
+                uri   : $uri,
+                method: $method,
+                params: ['hashes' => $chunk, ...$extra]
+            );
+            if ($response === false) {
+                $result = false;
+            }
+        }
+
+        return $result;
     }
 
     /**

--- a/src/back/Clients/Qbittorrent.php
+++ b/src/back/Clients/Qbittorrent.php
@@ -37,6 +37,8 @@ final class Qbittorrent implements ClientInterface
     use Traits\RetryMiddleware;
     use Traits\TopicIdSearch;
 
+    private const ACTION_CHUNK_SIZE = 500;
+
     /** Версия webApi. */
     private ?string $apiVersion = null;
 
@@ -130,7 +132,7 @@ final class Qbittorrent implements ClientInterface
 
         $this->logger->debug('Done processing', Timers::getStash());
 
-        return new Torrents($torrents);
+        return new Torrents(torrents: $torrents);
     }
 
     public function addTorrent(string $torrentFilePath, string $savePath = '', string $label = ''): bool
@@ -142,7 +144,7 @@ final class Qbittorrent implements ClientInterface
             return false;
         }
 
-        return $this->addTorrentContent($content, $savePath, $label);
+        return $this->addTorrentContent(content: $content, savePath: $savePath, label: $label);
     }
 
     public function addTorrentContent(string $content, string $savePath = '', string $label = ''): bool
@@ -158,12 +160,12 @@ final class Qbittorrent implements ClientInterface
         ];
 
         if (!empty($label)) {
-            $this->checkLabelExists($label);
+            $this->checkLabelExists(labelName: $label);
             $fields[] = ['name' => 'category', 'contents' => $label];
         }
 
         try {
-            $response = $this->client->post('torrents/add', ['multipart' => $fields]);
+            $response = $this->client->post(uri: 'torrents/add', options: ['multipart' => $fields]);
 
             return $response->getStatusCode() === 200;
         } catch (GuzzleException $e) {
@@ -182,90 +184,68 @@ final class Qbittorrent implements ClientInterface
 
     public function setLabel(array $torrentHashes, string $label = ''): bool
     {
-        $this->checkLabelExists($label);
+        $this->checkLabelExists(labelName: $label);
 
-        $fields = [
-            'hashes'   => implode('|', array_map('strtolower', $torrentHashes)),
-            'category' => $label,
-        ];
+        $success = true;
+        foreach (array_chunk($torrentHashes, self::ACTION_CHUNK_SIZE) as $chunk) {
+            $fields = [
+                'hashes'   => self::prepareHashes(hashes: $chunk),
+                'category' => $label,
+            ];
 
-        try {
-            $response = $this->request(url: 'torrents/setCategory', params: $fields);
+            try {
+                $response = $this->request(url: 'torrents/setCategory', params: $fields);
 
-            return $response->getStatusCode() === 200;
-        } catch (GuzzleException $e) {
-            if ($e->getCode() === 409) {
-                $this->logger->error('Category name does not exist', ['name' => $label]);
-            } else {
-                $this->logger->warning(
-                    'Failed to set category',
-                    ['code' => $e->getCode(), 'message' => $e->getMessage()]
-                );
+                if ($response->getStatusCode() !== 200) {
+                    $success = false;
+                }
+            } catch (GuzzleException $e) {
+                $success = false;
+                if ($e->getCode() === 409) {
+                    $this->logger->error('Category name does not exist', ['name' => $label]);
+                } else {
+                    $this->logger->warning(
+                        'Failed to set category',
+                        ['code' => $e->getCode(), 'message' => $e->getMessage()]
+                    );
+                }
             }
         }
 
-        return false;
-    }
-
-    public function createCategory(string $categoryName): void
-    {
-        $fields = [
-            'category' => $categoryName,
-            'savePath' => '',
-        ];
-
-        try {
-            $this->request(url: 'torrents/createCategory', params: $fields);
-        } catch (GuzzleException $e) {
-            $statusCode = $e->getCode();
-            if ($statusCode === 400) {
-                $this->logger->error('Category name is empty');
-            } elseif ($statusCode === 409) {
-                $this->logger->error('Category name is invalid', ['name' => $categoryName]);
-            }
-        }
+        return $success;
     }
 
     public function startTorrents(array $torrentHashes, bool $forceStart = false): bool
     {
-        $fields = ['hashes' => implode('|', array_map('strtolower', $torrentHashes))];
-
         $methodName = $this->getTorrentMethodName(method: 'start');
 
-        $startResult = $this->sendRequest(url: $methodName, params: $fields);
+        $result = $this->actionTorrents(url: $methodName, hashes: $torrentHashes);
 
         if ($forceStart) {
             // Прокидываем отдельный признак "принудительного запуска".
-            $this->sendRequest(url: 'torrents/setForceStart', params: ['value' => 'true', ...$fields]);
+            $this->actionTorrents(url: 'torrents/setForceStart', hashes: $torrentHashes, extra: ['value' => 'true']);
         }
 
-        return $startResult;
+        return $result;
     }
 
     public function stopTorrents(array $torrentHashes): bool
     {
-        $fields = ['hashes' => implode('|', array_map('strtolower', $torrentHashes))];
-
         $methodName = $this->getTorrentMethodName(method: 'stop');
 
-        return $this->sendRequest(url: $methodName, params: $fields);
+        return $this->actionTorrents(url: $methodName, hashes: $torrentHashes);
     }
 
     public function removeTorrents(array $torrentHashes, bool $deleteFiles = false): bool
     {
-        $fields = [
-            'hashes'      => implode('|', array_map('strtolower', $torrentHashes)),
-            'deleteFiles' => $deleteFiles ? 'true' : 'false',
-        ];
+        $extra = ['deleteFiles' => $deleteFiles ? 'true' : 'false'];
 
-        return $this->sendRequest(url: 'torrents/delete', params: $fields);
+        return $this->actionTorrents(url: 'torrents/delete', hashes: $torrentHashes, extra: $extra);
     }
 
     public function recheckTorrents(array $torrentHashes): bool
     {
-        $fields = ['hashes' => implode('|', array_map('strtolower', $torrentHashes))];
-
-        return $this->sendRequest(url: 'torrents/recheck', params: $fields);
+        return $this->actionTorrents(url: 'torrents/recheck', hashes: $torrentHashes);
     }
 
     /**
@@ -319,7 +299,7 @@ final class Qbittorrent implements ClientInterface
     {
         if ($this->authenticated) {
             try {
-                $response = $this->client->post('auth/logout', ['form_params' => []]);
+                $response = $this->client->post(uri: 'auth/logout', options: ['form_params' => []]);
 
                 $this->authenticated = !($response->getStatusCode() === 200);
 
@@ -378,16 +358,18 @@ final class Qbittorrent implements ClientInterface
     }
 
     /**
+     * @param literal-string       $url
      * @param array<string, mixed> $params
      *
      * @throws GuzzleException
      */
     private function request(string $url, array $params = []): ResponseInterface
     {
-        return $this->client->post($url, ['form_params' => $params]);
+        return $this->client->post(uri: $url, options: ['form_params' => $params]);
     }
 
     /**
+     * @param literal-string       $url
      * @param array<string, mixed> $params
      *
      * @return array<int|string, mixed>
@@ -406,6 +388,7 @@ final class Qbittorrent implements ClientInterface
     }
 
     /**
+     * @param literal-string       $url
      * @param array<string, mixed> $params
      */
     private function sendRequest(string $url, array $params = []): bool
@@ -419,6 +402,38 @@ final class Qbittorrent implements ClientInterface
         }
 
         return false;
+    }
+
+    /**
+     * Выполняет массовое действие над торрентами с разбивкой.
+     *
+     * @param literal-string       $url
+     * @param string[]             $hashes
+     * @param array<string, mixed> $extra
+     *
+     * @return bool true, если все части успешно обработаны, иначе false
+     */
+    private function actionTorrents(string $url, array $hashes, array $extra = []): bool
+    {
+        if ($hashes === []) {
+            return true;
+        }
+
+        $result = true;
+        foreach (array_chunk($hashes, self::ACTION_CHUNK_SIZE) as $chunk) {
+            $response = $this->sendRequest(
+                url   : $url,
+                params: [
+                    'hashes' => self::prepareHashes(hashes: $chunk),
+                    ...$extra,
+                ]
+            );
+            if ($response === false) {
+                $result = false;
+            }
+        }
+
+        return $result;
     }
 
     /**
@@ -448,6 +463,10 @@ final class Qbittorrent implements ClientInterface
 
     /**
      * Определить метод, который нужно вызвать в зависимости от версии webApi.
+     *
+     * @param literal-string $method
+     *
+     * @return literal-string
      */
     private function getTorrentMethodName(string $method): string
     {
@@ -472,6 +491,25 @@ final class Qbittorrent implements ClientInterface
         return sprintf('torrents/%s', $actions[$method] ?? '');
     }
 
+    private function createCategory(string $categoryName): void
+    {
+        $fields = [
+            'category' => $categoryName,
+            'savePath' => '',
+        ];
+
+        try {
+            $this->request(url: 'torrents/createCategory', params: $fields);
+        } catch (GuzzleException $e) {
+            $statusCode = $e->getCode();
+            if ($statusCode === 400) {
+                $this->logger->error('Category name is empty');
+            } elseif ($statusCode === 409) {
+                $this->logger->error('Category name is invalid', ['name' => $categoryName]);
+            }
+        }
+    }
+
     private function generateTorrentsList(bool $simpleRun): Generator
     {
         // Получаем и обрабатываем список раздач от клиента.
@@ -482,11 +520,11 @@ final class Qbittorrent implements ClientInterface
 
         if (!$simpleRun) {
             // Попытка найти ид раздачи в локальных таблицах.
-            $this->tryFillTopicIdFromTopics($torrents);
-            $this->tryFillTopicIdFromTorrents($torrents);
+            $this->tryFillTopicIdFromTopics(torrents: $torrents);
+            $this->tryFillTopicIdFromTorrents(torrents: $torrents);
 
             // Для раздач, у которых нет ид раздачи, вытаскиваем комментарий.
-            $this->tryFillTopicIdFromComments($torrents);
+            $this->tryFillTopicIdFromComments(torrents: $torrents);
         }
 
         foreach ($torrents as $hash => $torrent) {
@@ -626,7 +664,7 @@ final class Qbittorrent implements ClientInterface
         }
 
         if (!array_key_exists($labelName, $this->categories)) {
-            $this->createCategory($labelName);
+            $this->createCategory(categoryName: $labelName);
             $this->categories[$labelName] = [
                 'name' => $labelName,
             ];
@@ -642,14 +680,14 @@ final class Qbittorrent implements ClientInterface
     {
         Timers::start('comment_search');
 
-        $emptyTopics = self::getEmptyTopics($torrents);
+        $emptyTopics = self::getEmptyTopics(torrents: $torrents);
         if (count($emptyTopics)) {
             $this->logger->debug('Start search torrents in comment column', ['empty' => count($emptyTopics)]);
 
             foreach ($emptyTopics as $torrentHash => $torrent) {
-                $properties = $this->getProperties($torrent['client_hash']);
+                $properties = $this->getProperties(torrentHash: $torrent['client_hash']);
                 if (!empty($properties)) {
-                    $torrents[$torrentHash]['topic_id'] = $this->getTorrentTopicId($properties['comment']);
+                    $torrents[$torrentHash]['topic_id'] = $this->getTorrentTopicId(comment: $properties['comment']);
                     $torrents[$torrentHash]['comment']  = $properties['comment'];
                 }
 
@@ -659,6 +697,16 @@ final class Qbittorrent implements ClientInterface
             Timers::stash('comment_search');
             $this->logger->debug('End search torrents in comment column');
         }
+    }
+
+    /**
+     * Преобразует массив хэшей в строку, разделённую '|', с приведением к нижнему регистру.
+     *
+     * @param string[] $hashes
+     */
+    private static function prepareHashes(array $hashes): string
+    {
+        return implode('|', array_map('strtolower', $hashes));
     }
 
     private static function isTorrentStatePaused(string $state): bool

--- a/src/back/Clients/Rtorrent.php
+++ b/src/back/Clients/Rtorrent.php
@@ -16,12 +16,13 @@ use RuntimeException;
 use Throwable;
 
 /**
- * Class Rtorrent
+ * Class Rtorrent.
+ *
  * Supported by rTorrent 0.9.7 and later.
  *
- * https://rtorrent-docs.readthedocs.io/en/latest/scripting.html
- * https://php.watch/versions/8.0/xmlrpc#alternatives
- * https://github.com/gggeek/polyfill-xmlrpc
+ * @see https://rtorrent-docs.readthedocs.io/en/latest/scripting.html
+ * @see https://php.watch/versions/8.0/xmlrpc#alternatives
+ * @see https://github.com/gggeek/polyfill-xmlrpc
  */
 final class Rtorrent implements ClientInterface
 {
@@ -67,8 +68,8 @@ final class Rtorrent implements ClientInterface
     public function getTorrents(array $filter = []): Torrents
     {
         $response = $this->makeRequest(
-            'd.multicall2',
-            [
+            command: 'd.multicall2',
+            params : [
                 '',
                 'main',
                 'd.hash=',              // [0] хеш раздачи
@@ -122,7 +123,7 @@ final class Rtorrent implements ClientInterface
             unset($torrent, $torrentHash, $torrentComment, $trackerError, $progress, $storagePath);
         }
 
-        return new Torrents($torrents);
+        return new Torrents(torrents: $torrents);
     }
 
     public function addTorrent(string $torrentFilePath, string $savePath = '', string $label = ''): bool
@@ -171,28 +172,28 @@ final class Rtorrent implements ClientInterface
             ],
         ];
 
-        return $this->makeMultiCall($callsChain);
+        return $this->makeMultiCall(callsChain: $callsChain);
     }
 
     public function setLabel(array $torrentHashes, string $label = ''): bool
     {
-        $calls = $this->prepareHashesCalls('d.custom1.set', $torrentHashes, [$label]);
+        $calls = $this->prepareHashesCalls(method: 'd.custom1.set', hashes: $torrentHashes, params: [$label]);
 
-        return $this->actionTorrents($calls);
+        return $this->actionTorrents(calls: $calls);
     }
 
     public function startTorrents(array $torrentHashes, bool $forceStart = false): bool
     {
-        $calls = $this->prepareHashesCalls('d.start', $torrentHashes);
+        $calls = $this->prepareHashesCalls(method: 'd.start', hashes: $torrentHashes);
 
-        return $this->actionTorrents($calls);
+        return $this->actionTorrents(calls: $calls);
     }
 
     public function stopTorrents(array $torrentHashes): bool
     {
-        $calls = $this->prepareHashesCalls('d.stop', $torrentHashes);
+        $calls = $this->prepareHashesCalls(method: 'd.stop', hashes: $torrentHashes);
 
-        return $this->actionTorrents($calls);
+        return $this->actionTorrents(calls: $calls);
     }
 
     public function removeTorrents(array $torrentHashes, bool $deleteFiles = false): bool
@@ -201,7 +202,7 @@ final class Rtorrent implements ClientInterface
         foreach ($torrentHashes as $torrentHash) {
             $executeDeleteFiles = ['', 'true'];
             if ($deleteFiles) {
-                $dataPath = $this->makeRequest('d.data_path', [$torrentHash]);
+                $dataPath = $this->makeRequest(command: 'd.data_path', params: [$torrentHash]);
                 if (!empty($dataPath)) {
                     $executeDeleteFiles = ['', 'rm', '-rf', '--', $dataPath];
                 }
@@ -226,7 +227,7 @@ final class Rtorrent implements ClientInterface
                 ],
             ];
 
-            $response = $this->makeMultiCall($chainCalls);
+            $response = $this->makeMultiCall(callsChain: $chainCalls);
             if ($response === false) {
                 $result = false;
             }
@@ -237,9 +238,9 @@ final class Rtorrent implements ClientInterface
 
     public function recheckTorrents(array $torrentHashes): bool
     {
-        $calls = $this->prepareHashesCalls('d.check_hash', $torrentHashes);
+        $calls = $this->prepareHashesCalls(method: 'd.check_hash', hashes: $torrentHashes);
 
-        return $this->actionTorrents($calls);
+        return $this->actionTorrents(calls: $calls);
     }
 
     /**
@@ -249,11 +250,11 @@ final class Rtorrent implements ClientInterface
     {
         if (!$this->authenticated) {
             try {
-                $xml = $this->xmpRequestEncode('session.name');
+                $xml = $this->xmpRequestEncode(command: 'session.name');
 
-                $response = $this->client->post('', ['body' => $xml]);
+                $response = $this->client->post(uri: '', options: ['body' => $xml]);
 
-                $result = $this->xmlResponseDecode($response->getBody()->getContents());
+                $result = $this->xmlResponseDecode(response: $response->getBody()->getContents());
 
                 // Проверяем статус авторизации.
                 $this->authenticated =
@@ -287,18 +288,20 @@ final class Rtorrent implements ClientInterface
     }
 
     /**
+     * @param literal-string    $command
      * @param array<int, mixed> $params
      *
      * @throws GuzzleException
      */
     private function request(string $command, array $params = []): ResponseInterface
     {
-        $options = ['body' => $this->xmpRequestEncode($command, $params)];
+        $options = ['body' => $this->xmpRequestEncode(command: $command, params: $params)];
 
         return $this->client->post(uri: '', options: $options);
     }
 
     /**
+     * @param literal-string    $command
      * @param array<int, mixed> $params
      *
      * @return array<int, mixed>
@@ -315,10 +318,11 @@ final class Rtorrent implements ClientInterface
 
         $content = $response->getBody()->getContents();
 
-        return (array) $this->xmlResponseDecode($content);
+        return (array) $this->xmlResponseDecode(response: $content);
     }
 
     /**
+     * @param literal-string    $command
      * @param array<int, mixed> $params
      */
     private function sendRequest(string $command, array $params = []): bool
@@ -331,7 +335,7 @@ final class Rtorrent implements ClientInterface
             }
 
             $content = $response->getBody()->getContents();
-            $result  = $this->xmlResponseDecode($content);
+            $result  = $this->xmlResponseDecode(response: $content);
 
             return !empty($result);
         } catch (Throwable $e) {
@@ -348,20 +352,20 @@ final class Rtorrent implements ClientInterface
      */
     private function makeMultiCall(array $callsChain): bool
     {
-        return $this->sendRequest('system.multicall', [$callsChain]);
+        return $this->sendRequest(command: 'system.multicall', params: [$callsChain]);
     }
 
     /**
-     * @param string[]          $torrentHashes
+     * @param string[]          $hashes
      * @param array<int, mixed> $params
      *
      * @return array<array<string, mixed>>
      */
-    private function prepareHashesCalls(string $method, array $torrentHashes, array $params = []): array
+    private function prepareHashesCalls(string $method, array $hashes, array $params = []): array
     {
-        $callback = fn($hash) => ['methodName' => $method, 'params' => [$hash, ...$params]];
+        $callback = static fn($hash) => ['methodName' => $method, 'params' => [$hash, ...$params]];
 
-        return array_map($callback, $torrentHashes);
+        return array_map($callback, $hashes);
     }
 
     /**
@@ -369,6 +373,10 @@ final class Rtorrent implements ClientInterface
      */
     private function actionTorrents(array $calls): bool
     {
+        if ($calls === []) {
+            return true;
+        }
+
         // Разделяем необходимые запросы на группы.
         $callsChunks = array_chunk(
             $calls,
@@ -377,7 +385,7 @@ final class Rtorrent implements ClientInterface
 
         $result = true;
         foreach ($callsChunks as $callsChain) {
-            $response = $this->makeMultiCall($callsChain);
+            $response = $this->makeMultiCall(callsChain: $callsChain);
             if ($response === false) {
                 $result = false;
             }
@@ -387,6 +395,7 @@ final class Rtorrent implements ClientInterface
     }
 
     /**
+     * @param literal-string    $command
      * @param array<int, mixed> $params
      */
     private function xmpRequestEncode(string $command, array $params = []): string

--- a/src/back/Clients/Transmission.php
+++ b/src/back/Clients/Transmission.php
@@ -20,10 +20,11 @@ use RuntimeException;
 use Throwable;
 
 /**
- * Class Transmission
+ * Class Transmission.
+ *
  * Supported by Transmission 2.80 and later.
  *
- * https://github.com/transmission/transmission/blob/main/docs/rpc-spec.md
+ * @see https://github.com/transmission/transmission/blob/main/docs/rpc-spec.md
  */
 final class Transmission implements ClientInterface
 {
@@ -34,6 +35,8 @@ final class Transmission implements ClientInterface
     use Traits\RetryMiddleware;
 
     private const TOKEN = 'X-Transmission-Session-Id';
+
+    private const ACTION_CHUNK_SIZE = 500;
 
     /**
      * Заголовки для хранения ключа авторизации.
@@ -99,7 +102,7 @@ final class Transmission implements ClientInterface
             ],
         ];
         Timers::start('torrents_info');
-        $response = $this->makeRequest('torrent-get', $fields);
+        $response = $this->makeRequest(method: 'torrent-get', params: $fields);
         Timers::stash('torrents_info');
 
         $torrents = $brokenFiles = [];
@@ -133,9 +136,9 @@ final class Transmission implements ClientInterface
                 topicHash   : $torrentHash,
                 clientHash  : $torrentHash,
                 name        : $torrentName,
-                topicId     : $this->getTorrentTopicId($torrent['comment']),
+                topicId     : $this->getTorrentTopicId(comment: $torrent['comment']),
                 size        : (int) $torrent['totalSize'],
-                added       : DateHelper::makeFromTimestamp((int) $torrent['addedDate']),
+                added       : DateHelper::makeFromTimestamp(timestamp: (int) $torrent['addedDate']),
                 done        : $progress,
                 paused      : (int) $torrent['status'] === 0,
                 error       : (int) $torrent['error'] !== 0,
@@ -155,7 +158,7 @@ final class Transmission implements ClientInterface
             $this->logger->debug('Broken encoding detected.', array_values($brokenFiles));
         }
 
-        return new Torrents($torrents);
+        return new Torrents(torrents: $torrents);
     }
 
     public function addTorrent(string $torrentFilePath, string $savePath = '', string $label = ''): bool
@@ -167,7 +170,7 @@ final class Transmission implements ClientInterface
             return false;
         }
 
-        return $this->addTorrentContent($content, $savePath, $label);
+        return $this->addTorrentContent(content: $content, savePath: $savePath, label: $label);
     }
 
     public function addTorrentContent(string $content, string $savePath = '', string $label = ''): bool
@@ -180,10 +183,10 @@ final class Transmission implements ClientInterface
             $fields['download-dir'] = $savePath;
         }
         if (!empty($label)) {
-            $fields['labels'] = [$this->prepareLabel($label)];
+            $fields['labels'] = [$this->prepareLabel(label: $label)];
         }
 
-        $result = $this->makeRequest('torrent-add', $fields);
+        $result = $this->makeRequest(method: 'torrent-add', params: $fields);
         if (!empty($result['torrent-duplicate'])) {
             $torrentHash = $result['torrent-duplicate']['hashString'];
             $this->logger->notice('This torrent already added', ['hash' => $torrentHash]);
@@ -203,50 +206,37 @@ final class Transmission implements ClientInterface
             return false;
         }
 
-        $fields = [
-            'labels' => [$this->prepareLabel($label)],
-            'ids'    => $torrentHashes,
-        ];
-
-        return $this->sendRequest('torrent-set', $fields);
+        return $this->actionTorrents(
+            method: 'torrent-set',
+            hashes: $torrentHashes,
+            extra : ['labels' => [$this->prepareLabel(label: $label)]],
+        );
     }
 
     public function startTorrents(array $torrentHashes, bool $forceStart = false): bool
     {
         $method = $forceStart ? 'torrent-start-now' : 'torrent-start';
-        $fields = [
-            'ids' => $torrentHashes,
-        ];
 
-        return $this->sendRequest($method, $fields);
+        return $this->actionTorrents(method: $method, hashes: $torrentHashes);
     }
 
     public function stopTorrents(array $torrentHashes): bool
     {
-        $fields = [
-            'ids' => $torrentHashes,
-        ];
-
-        return $this->sendRequest('torrent-stop', $fields);
+        return $this->actionTorrents(method: 'torrent-stop', hashes: $torrentHashes);
     }
 
     public function recheckTorrents(array $torrentHashes): bool
     {
-        $fields = [
-            'ids' => $torrentHashes,
-        ];
-
-        return $this->sendRequest('torrent-verify', $fields);
+        return $this->actionTorrents(method: 'torrent-verify', hashes: $torrentHashes);
     }
 
     public function removeTorrents(array $torrentHashes, bool $deleteFiles = false): bool
     {
-        $fields = [
-            'ids'               => $torrentHashes,
-            'delete-local-data' => $deleteFiles,
-        ];
-
-        return $this->sendRequest('torrent-remove', $fields);
+        return $this->actionTorrents(
+            method: 'torrent-remove',
+            hashes: $torrentHashes,
+            extra : ['delete-local-data' => $deleteFiles],
+        );
     }
 
     /**
@@ -256,8 +246,8 @@ final class Transmission implements ClientInterface
     {
         if (!$this->authenticated) {
             try {
-                $response = $this->request('session-get');
-                $result   = $this->validateResponse($response);
+                $response = $this->request(method: 'session-get');
+                $result   = $this->validateResponse(response: $response);
 
                 // Если получили ответ, значит авторизация успешна.
                 if (!empty($result['rpc-version'])) {
@@ -302,6 +292,7 @@ final class Transmission implements ClientInterface
     }
 
     /**
+     * @param literal-string       $method
      * @param array<string, mixed> $options
      *
      * @throws GuzzleException
@@ -318,10 +309,11 @@ final class Transmission implements ClientInterface
             'body'    => json_encode($params),
         ];
 
-        return $this->client->post('', $options);
+        return $this->client->post(uri: '', options: $options);
     }
 
     /**
+     * @param literal-string       $method
      * @param array<string, mixed> $params
      *
      * @return array<string, mixed>
@@ -329,23 +321,24 @@ final class Transmission implements ClientInterface
     private function makeRequest(string $method, array $params = []): array
     {
         try {
-            $response = $this->request($method, $params);
+            $response = $this->request(method: $method, options: $params);
         } catch (GuzzleException $e) {
             $this->logger->error('Failed to make request', ['code' => $e->getCode(), 'message' => $e->getMessage()]);
 
             throw new RuntimeException('Failed to make request');
         }
 
-        return $this->validateResponse($response);
+        return $this->validateResponse(response: $response);
     }
 
     /**
+     * @param literal-string       $method
      * @param array<string, mixed> $params
      */
     private function sendRequest(string $method, array $params = []): bool
     {
         try {
-            $response = $this->request($method, $params);
+            $response = $this->request(method: $method, options: $params);
 
             return $response->getStatusCode() === 200;
         } catch (Throwable $e) {
@@ -353,6 +346,35 @@ final class Transmission implements ClientInterface
         }
 
         return false;
+    }
+
+    /**
+     * Выполняет массовое действие над торрентами с разбивкой.
+     *
+     * @param literal-string       $method
+     * @param string[]             $hashes
+     * @param array<string, mixed> $extra
+     *
+     * @return bool true, если все части успешно обработаны, иначе false
+     */
+    private function actionTorrents(string $method, array $hashes, array $extra = []): bool
+    {
+        if ($hashes === []) {
+            return true;
+        }
+
+        $result = true;
+        foreach (array_chunk($hashes, self::ACTION_CHUNK_SIZE) as $chunk) {
+            $response = $this->sendRequest(
+                method: $method,
+                params: ['ids' => $chunk, ...$extra],
+            );
+            if ($response === false) {
+                $result = false;
+            }
+        }
+
+        return $result;
     }
 
     /**

--- a/src/back/Clients/Utorrent.php
+++ b/src/back/Clients/Utorrent.php
@@ -22,10 +22,11 @@ use RuntimeException;
 use Throwable;
 
 /**
- * Class Utorrent
+ * Class Utorrent.
+ *
  * Supported by uTorrent 1.8.2 and later.
  *
- * https://forum.utorrent.com/topic/21814-web-ui-api/
+ * @see https://forum.utorrent.com/topic/21814-web-ui-api/
  */
 final class Utorrent implements ClientInterface
 {
@@ -37,6 +38,8 @@ final class Utorrent implements ClientInterface
     use Traits\TopicIdSearch;
 
     private const HashesPerRequest = 32;
+
+    private const ACTION_CHUNK_SIZE = 100;
 
     private string $token;
 
@@ -101,7 +104,7 @@ final class Utorrent implements ClientInterface
 
         $this->logger->debug('Done processing', Timers::getStash());
 
-        return new Torrents($torrents);
+        return new Torrents(torrents: $torrents);
     }
 
     public function addTorrent(string $torrentFilePath, string $savePath = '', string $label = ''): bool
@@ -113,14 +116,14 @@ final class Utorrent implements ClientInterface
             return false;
         }
 
-        return $this->addTorrentContent($content, $savePath, $label);
+        return $this->addTorrentContent(content: $content, savePath: $savePath, label: $label);
     }
 
     public function addTorrentContent(string $content, string $savePath = '', string $label = ''): bool
     {
-        $this->setSetting('dir_active_download_flag', '1');
+        $this->setSetting(setting: 'dir_active_download_flag', value: '1');
         if (!empty($savePath)) {
-            $this->setSetting('dir_active_download', $savePath);
+            $this->setSetting(setting: 'dir_active_download', value: $savePath);
             sleep(1);
         }
 
@@ -137,7 +140,7 @@ final class Utorrent implements ClientInterface
         $query = $this->buildHttpQuery(method: 'action', action: 'add-file');
 
         try {
-            $response = $this->client->post('', ['query' => $query, 'multipart' => $fields]);
+            $response = $this->client->post(uri: '', options: ['query' => $query, 'multipart' => $fields]);
 
             return $response->getStatusCode() === 200;
         } catch (GuzzleException $e) {
@@ -152,36 +155,36 @@ final class Utorrent implements ClientInterface
 
     public function setLabel(array $torrentHashes, string $label = ''): bool
     {
-        return $this->setProperties($torrentHashes, 'label', $label);
+        return $this->setProperties(hashes: $torrentHashes, property: 'label', value: $label);
     }
 
     public function startTorrents(array $torrentHashes, bool $forceStart = false): bool
     {
         $action = $forceStart ? 'forcestart' : 'start';
 
-        return $this->sendRequest(action: $action, params: ['hashes' => $torrentHashes]);
+        return $this->actionTorrents(action: $action, hashes: $torrentHashes);
+    }
+
+    public function stopTorrents(array $torrentHashes): bool
+    {
+        return $this->actionTorrents(action: 'stop', hashes: $torrentHashes);
     }
 
     public function recheckTorrents(array $torrentHashes): bool
     {
         // uTorrent может перехешировать только остановленные раздачи.
-        if ($this->stopTorrents($torrentHashes)) {
-            return $this->sendRequest(action: 'recheck', params: ['hashes' => $torrentHashes]);
+        if ($this->stopTorrents(torrentHashes: $torrentHashes)) {
+            return $this->actionTorrents(action: 'recheck', hashes: $torrentHashes);
         }
 
         return false;
-    }
-
-    public function stopTorrents(array $torrentHashes): bool
-    {
-        return $this->sendRequest(action: 'stop', params: ['hashes' => $torrentHashes]);
     }
 
     public function removeTorrents(array $torrentHashes, bool $deleteFiles = false): bool
     {
         $action = $deleteFiles ? 'removedata' : 'remove';
 
-        return $this->sendRequest(action: $action, params: ['hashes' => $torrentHashes]);
+        return $this->actionTorrents(action: $action, hashes: $torrentHashes);
     }
 
     /**
@@ -191,7 +194,7 @@ final class Utorrent implements ClientInterface
     {
         if (!$this->authenticated) {
             try {
-                $response = $this->client->post('token.html');
+                $response = $this->client->post(uri: 'token.html');
 
                 $html = $response->getBody()->getContents();
 
@@ -229,7 +232,9 @@ final class Utorrent implements ClientInterface
     }
 
     /**
+     * @param literal-string       $action
      * @param array<string, mixed> $params
+     * @param literal-string       $method
      *
      * @throws GuzzleException
      */
@@ -239,18 +244,20 @@ final class Utorrent implements ClientInterface
         // hash=hash1&hash=hash2...
         $hashes = [];
         if (!empty($params['hashes'])) {
-            $hashes = array_map(fn($el) => "hash=$el", $params['hashes']);
+            $hashes = array_map(static fn($el) => "hash=$el", $params['hashes']);
         }
         unset($params['hashes']);
 
         $props = $this->buildHttpQuery(method: $method, action: $action, params: $params);
         $query = implode('&', [$props, ...$hashes]);
 
-        return $this->client->get('', ['query' => $query]);
+        return $this->client->get(uri: '', options: ['query' => $query]);
     }
 
     /**
+     * @param literal-string       $action
      * @param array<string, mixed> $params
+     * @param literal-string       $method
      *
      * @return array<string, mixed>
      */
@@ -268,7 +275,9 @@ final class Utorrent implements ClientInterface
     }
 
     /**
+     * @param literal-string       $action
      * @param array<string, mixed> $params
+     * @param literal-string       $method
      */
     private function sendRequest(string $action, array $params = [], string $method = 'action'): bool
     {
@@ -284,8 +293,39 @@ final class Utorrent implements ClientInterface
     }
 
     /**
+     * Выполняет массовое действие над торрентами с разбивкой.
+     *
+     * @param literal-string       $action
+     * @param string[]             $hashes
+     * @param array<string, mixed> $extra
+     *
+     * @return bool true, если все части успешно обработаны, иначе false
+     */
+    private function actionTorrents(string $action, array $hashes, array $extra = []): bool
+    {
+        if ($hashes === []) {
+            return true;
+        }
+
+        $result = true;
+        foreach (array_chunk($hashes, self::ACTION_CHUNK_SIZE) as $chunk) {
+            $response = $this->sendRequest(
+                action: $action,
+                params: ['hashes' => $chunk, ...$extra]
+            );
+            if ($response === false) {
+                $result = false;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
      * Кодируем выполняемое действие + токен авторизации.
      *
+     * @param literal-string       $method
+     * @param literal-string       $action
      * @param array<string, mixed> $params
      */
     private function buildHttpQuery(string $method, string $action, array $params = []): string
@@ -323,8 +363,8 @@ final class Utorrent implements ClientInterface
 
         if (!$simpleRun) {
             // Попытка найти ид раздачи в локальных таблицах.
-            $this->tryFillTopicIdFromTopics($torrents);
-            $this->tryFillTopicIdFromTorrents($torrents);
+            $this->tryFillTopicIdFromTopics(torrents: $torrents);
+            $this->tryFillTopicIdFromTorrents(torrents: $torrents);
         }
 
         foreach ($torrents as $hash => $torrent) {
@@ -403,7 +443,7 @@ final class Utorrent implements ClientInterface
         // Экранируем значение, т.к. передавать будем GET-ом.
         $value = urlencode($value);
         // Создаём строки присвоение значения каждому хешу.
-        $hashes = array_map(fn($hash) => sprintf('%s&s=%s&v=%s', $hash, $property, $value), $hashes);
+        $hashes = array_map(static fn($hash) => sprintf('%s&s=%s&v=%s', $hash, $property, $value), $hashes);
 
         // Делим итоговый список на части.
         $hashesChunks = array_chunk($hashes, self::HashesPerRequest);


### PR DESCRIPTION
close #259

Для всех клиентов проведена оптимизация кода, в частности операции теперь делятся на части и выполняются последовательно.
Операции: `setLabel`, `startTorrents`, `stopTorrents`, `recheckTorrents`, `removeTorrents`

Клиенты `Deluge`, `Flood`, `Qbittorrent`, `Transmission` - по 500 хешей за раз. Некоторые методы не поддерживают более одного хеша.
Для `Rtorrent` - 32 хеша за часть уже было.
Для `Utorrent` - 32/100 хешей за раз, в зависимости от метода.