### PR TITLE
UI. Добавлена возможность сохранять пресеты фильтров в списке раздач.

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -131,11 +131,6 @@ li.menu.ui-tabs-active {
     cursor: default;
 }
 
-.ui-button.ui-button-icon-only.split-button-select {
-    width: 1em;
-    padding: .4em .1em;
-}
-
 .ui-menu-update-info .ui-menu-item-wrapper.ui-state-active {
     color: #28a745;
 }
@@ -238,6 +233,16 @@ li.menu.ui-tabs-active {
 
 #topics_control {
     padding: 10px;
+}
+
+/* Размеры кнопок в панели */
+#topics_control .ui-button {
+    padding: .4em .9em;
+}
+
+#topics_control .ui-button.ui-button-icon-only.split-button-select {
+    width: 1em;
+    padding: .4em .1em;
 }
 
 .download-replace {

--- a/public/index.php
+++ b/public/index.php
@@ -1190,6 +1190,7 @@ $cs = static function(string $section, string $key, int|string $default = '') us
                         <li class="menu"><a href="#log_keepers" class="menu log_file">keepers</a></li>
                         <li class="menu"><a href="#log_reports" class="menu log_file">reports</a></li>
                         <li class="menu"><a href="#log_control" class="menu log_file">control</a></li>
+                        <li class="menu"><a href="#log_topics" class="menu log_file">topics</a></li>
                     </ul>
                     <div id="log_content">
                         <div id="log"></div>
@@ -1197,6 +1198,7 @@ $cs = static function(string $section, string $key, int|string $default = '') us
                         <div id="log_keepers"></div>
                         <div id="log_reports"></div>
                         <div id="log_control"></div>
+                        <div id="log_topics"></div>
                     </div>
                 </div>
             </div>

--- a/public/index.php
+++ b/public/index.php
@@ -172,6 +172,29 @@ $cs = static function(string $section, string $key, int|string $default = '') us
                                 <i class="fa fa-times" aria-hidden="true"></i>
                             </button>
                         </div>
+
+                        <div class="control-group">
+                            <button id="preset_toggle" title="Показать/скрыть панель пресетов.">
+                                <i class="fa fa-layer-group" aria-hidden="true"></i>
+                            </button>
+                        </div>
+
+                        <div id="preset_controls" class="control-group">
+                            <select id="preset_select">
+                                <option value="">[[Выберите пресет]]</option>
+                            </select>
+
+                            <button id="preset_apply" class="preset-unsaved" title="Применить выбранный пресет.">
+                                <i class="fa fa-check" aria-hidden="true"></i>
+                            </button>
+                            <button id="preset_save" class="preset-unsaved" title="Сохранить текущий фильтр как пресет.&#10;Ctrl+Click показать дополнительную панель управления.">
+                                <i class="fa fa-save" aria-hidden="true"></i>
+                            </button>
+                            <button id="preset_delete" title="Удалить выбранный пресет.">
+                                <i class="fa fa-trash" aria-hidden="true"></i>
+                            </button>
+                        </div>
+
                         <div class="control-group">
                             <button type="button" id="update_info" name="update_info" title="Обновить сведения о раздачах">
                                 <i class="fa fa-refresh" aria-hidden="true"></i>
@@ -180,10 +203,12 @@ $cs = static function(string $section, string $key, int|string $default = '') us
                             <select id="update_info_select" class="filter-select-menu">
                             </select>
                         </div>
+
                         <button class="send_reports" name="send_reports" type="button"
                                 title="Отправить отчёты на форум. &#10;Ctrl+Click отправит `чистый` отчёт.">
                             <i class="fa fa-paper-plane-o" aria-hidden="true"></i> Отправить отчёты
                         </button>
+
                         <button id="control_torrents" name="control_torrents" type="button" title="Выполнить регулировку раздач в торрент-клиентах">
                             <i class="fa fa-adjust" aria-hidden="true"></i> Регулировка раздач
                         </button>
@@ -193,6 +218,7 @@ $cs = static function(string $section, string $key, int|string $default = '') us
                             <div class="process-loading process-status"></div>
                         </div>
                     </div>
+
                     <form method="post" id="topics_filter">
                         <div class="topics_filter">
                             <div class="filter_block ui-widget">
@@ -1205,6 +1231,7 @@ $cs = static function(string $section, string $key, int|string $default = '') us
     <script type="text/javascript" src="scripts/lib.common.js"></script>
     <script type="text/javascript" src="scripts/lib.config.js"></script>
     <script type="text/javascript" src="scripts/lib.forum.js"></script>
+    <script type="text/javascript" src="scripts/lib.preset.js"></script>
     <script type="text/javascript" src="scripts/lib.topics.js"></script>
 
     <!-- Реестр модулей-->

--- a/public/php/filter_presets_manager.php
+++ b/public/php/filter_presets_manager.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+use KeepersTeam\Webtlo\Helper;
+
+$presetsFile = Helper::getStorageDir() . '/filter_presets.json';
+
+// Инициализация пустого файла, если его нет.
+if (!file_exists($presetsFile)) {
+    file_put_contents($presetsFile, '{}');
+}
+
+$action = $_GET['action'] ?? $_POST['action'] ?? 'list';
+
+// Чтение текущих пресетов.
+$presets = json_decode((string) file_get_contents($presetsFile), true);
+if (!is_array($presets)) {
+    $presets = [];
+}
+
+header('Content-Type: application/json');
+
+switch ($action) {
+    case 'list':
+        echo json_encode(array_keys($presets));
+        exit;
+
+    case 'load':
+        $name = $_GET['name'] ?? '';
+        if (isset($presets[$name])) {
+            echo json_encode($presets[$name]);
+        } else {
+            http_response_code(404);
+
+            echo json_encode(['error' => 'Preset not found']);
+        }
+
+        exit;
+
+    case 'save':
+        $name = $_POST['name'] ?? '';
+        $data = isset($_POST['data']) ? json_decode($_POST['data'], true) : null;
+
+        if (!$name || !$data) {
+            http_response_code(400);
+
+            echo json_encode(['error' => 'Invalid data']);
+
+            exit;
+        }
+
+        // Проверка на дубликат: можно перезаписывать или выдавать ошибку.
+        $presets[$name] = $data;
+        file_put_contents($presetsFile, json_encode($presets, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+
+        echo json_encode(['success' => true]);
+
+        exit;
+
+    case 'delete':
+        $name = $_POST['name'] ?? '';
+
+        if (isset($presets[$name])) {
+            unset($presets[$name]);
+            file_put_contents($presetsFile, json_encode($presets, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+
+            echo json_encode(['success' => true]);
+        } else {
+            http_response_code(404);
+
+            echo json_encode(['error' => 'Preset not found']);
+        }
+        exit;
+
+    default:
+        http_response_code(400);
+
+        echo json_encode(['error' => 'Unknown action']);
+}

--- a/public/scripts/lib.common.js
+++ b/public/scripts/lib.common.js
@@ -55,14 +55,14 @@ let processStatus = {
 let lock_actions = 0;
 function block_actions() {
     let buttons = $('#topics_control button')
-        .add("button.send_reports")
+        .add('button.send_reports')
         .not('button.disabled-manual');
 
 
     if (lock_actions === 0) {
         buttons.toggleDisable(true);
 
-        $("#main-subsections, .filter-select-menu").selectmenu("disable");
+        $('#main-subsections, #preset_select, .filter-select-menu').selectmenu('disable');
 
         processStatus.show();
         lock_actions = 1;
@@ -70,14 +70,14 @@ function block_actions() {
         buttons.toggleDisable(false);
 
         if (
-            $("#main-subsections").val() < 1
-            || !$("input[name=filter_status]").eq(1).prop("checked")
+            $('#main-subsections').val() < 1
+            || !$('input[name=filter_status]').eq(1).prop('checked')
         ) {
-            $(".tor_add").toggleDisable(true);
+            $('.tor_add').toggleDisable(true);
         } else {
-            $(".tor_stop, .tor_remove, .tor_label, .tor_start").toggleDisable(true);
+            $('.tor_stop, .tor_remove, .tor_label, .tor_start').toggleDisable(true);
         }
-        $("#main-subsections, .filter-select-menu").selectmenu("enable");
+        $('#main-subsections, #preset_select, .filter-select-menu').selectmenu('enable');
 
         processStatus.hide();
         lock_actions = 0;

--- a/public/scripts/lib.preset.js
+++ b/public/scripts/lib.preset.js
@@ -1,0 +1,317 @@
+/* Функции для работы с наборами фильтров. */
+
+
+let lastUsedFilter = null;
+
+/**
+ * Изменился ли последний использованный пресет, относительно текущего.
+ *
+ * @return {boolean}
+ */
+function checkUsedFilterChange() {
+    // Текущий отсортированный набор фильтров.
+    const currentFilter = getCurrentFilter();
+    const currentFilterString = JSON.stringify(currentFilter);
+
+    // Если прошлый набор фильтров идентичен текущему - ничего не делаем.
+    if (lastUsedFilter === currentFilterString) {
+        return false;
+    }
+
+    // Запоминаем параметры фильтра в куки.
+    lastUsedFilter = currentFilterString;
+    Cookies.set('filter-options', currentFilter);
+
+    return true;
+}
+
+/**
+ * Текущий фильтр из формы.
+ *
+ * @return {Object}
+ * @see https://github.com/marioizquierdo/jquery.serializeJSON/issues/49
+ */
+function getCurrentFilter() {
+    const $form = $('#topics_filter');
+
+    const $disabledFields = $form.find(':disabled');
+    $disabledFields.prop('disabled', false);
+
+    const filter = $form.serializeSortedJSON();
+    $disabledFields.prop('disabled', true);
+
+    return filter;
+}
+
+/**
+ * Загрузка списка пресетов при старте.
+ *
+ * @param {?string} lastSelectedPreset
+ */
+function loadPresetList(lastSelectedPreset = null) {
+    $.get('php/filter_presets_manager.php?action=list', function(names) {
+        let $select = $('#preset_select');
+        $select.find('option:not(:first)').remove();
+
+        $.each(names, function(i, name) {
+            $select.append($('<option>', {value: name, text: name}));
+        });
+
+        // Выбираем активный пресет.
+        if (lastSelectedPreset) {
+            $select.val(lastSelectedPreset);
+        }
+
+        $select.selectmenu('refresh');
+        toggleButtonUnsavedState(false);
+    });
+}
+
+/**
+ * Сохранение текущего фильтра как пресета
+ */
+function saveCurrentFilter() {
+    const filter = getCurrentFilter();
+
+    let name = $('#preset_select').val();
+    if (name) {
+        // Используем старое имя пресета, если есть.
+        if (!confirm(`Перезаписать пресет "${name}" текущим набором фильтров?`)) return;
+    } else {
+        // Запрашиваем новое имя через диалог.
+        name = prompt('Введите имя для нового пресета:');
+    }
+
+    if (!name || name.trim() === '') return;
+
+    savePreset(name, filter);
+}
+
+/**
+ * Записать пресет.
+ *
+ * @param {string} name
+ * @param {Object} filter
+ */
+function savePreset(name, filter) {
+    $.post('php/filter_presets_manager.php', {
+        action: 'save',
+        name  : name.trim(),
+        data  : JSON.stringify(filter)
+    }, function(response) {
+        if (response.success) {
+            // Обновляем список.
+            loadPresetList(name);
+
+            showResultTopics(`Пресет "${name.trim()}" сохранён.`);
+        } else {
+            showResultTopics(`Ошибка сохранения: ${response.error || 'неизвестная ошибка'}`);
+        }
+    }, 'json');
+}
+
+
+/**
+ * Применение выбранного пресета.
+ */
+function applySelectedPreset() {
+    const name = $('#preset_select').val();
+    if (!name) return;
+
+    $.getJSON('php/filter_presets_manager.php?action=load&name=' + encodeURIComponent(name), function(data) {
+        // Раскладываем фильтр по полям.
+        loadSavedFilterOptions(JSON.stringify(data));
+        toggleButtonUnsavedState(false);
+
+        // Применяем фильтр.
+        $('#topics_filter').trigger('manual_change');
+    });
+}
+
+/**
+ * Удаление выбранного пресета.
+ */
+function deleteSelectedPreset() {
+    const name = $('#preset_select').val();
+    if (!name) return;
+    if (!confirm(`Удалить пресет "${name}"?`)) return;
+
+    $.post('php/filter_presets_manager.php', {
+        action: 'delete',
+        name  : name
+    }, function(response) {
+        if (response.success) {
+            showResultTopics(`Пресет "${name}" удалён.`);
+
+            loadPresetList();
+            toggleButtonUnsavedState(false);
+        } else {
+            showResultTopics(`Ошибка удаления: ${response.error || 'неизвестная ошибка'}`);
+        }
+    }, 'json');
+}
+
+/**
+ * Разложить сохранённый набор фильтров по полям.
+ *
+ * @param {string} filter_options JSON строка с набором фильтров.
+ */
+function loadSavedFilterOptions(filter_options) {
+    filter_options = $.parseJSON(filter_options);
+
+    // Снимаем галку со всех доступных элементов фильтра.
+    $('#topics_filter').find(':checkbox, :radio').prop('checked', false);
+
+    // Перебираем пресет и ставим нужные галки.
+    $.each(filter_options, function(option_name, value) {
+        // Пропускаем "дату регистрации до".
+        if (option_name === 'filter_date_release') {
+            return;
+        }
+
+        // Обрабатываем селекторы.
+        if ($(`#topics_filter [name='${option_name}']`).is('select')) {
+            $(`#${option_name}`).val(value).selectmenu('refresh');
+
+            return;
+        }
+
+        // Если имеем список значений, значит это группированный элемент вида "option_name[]".
+        if (typeof(value) === 'object' && value !== null) {
+            $.each(value, function(i, in_value) {
+                if (typeof (i) === 'number') {
+                    applyOptionWithValue(`${option_name}[]`, in_value);
+                } else {
+                    applyOptionWithValue(`${option_name}[${i}]`, in_value);
+                }
+            })
+
+            return;
+        }
+
+        // Одиночные элементы.
+        applyOptionWithValue(option_name, value);
+    });
+
+    // вкл/выкл интервал сидов
+    $('#topics_filter input[name=filter_interval]').trigger('filter_init');
+
+    // вкл/выкл интервал хранителей
+    $('#topics_filter input[name=is_keepers]').trigger('filter_init');
+
+    // Обновить выбранные статусы хранения раздач.
+    $('.filter_status_controlgroup').controlgroup('refresh');
+
+
+    /**
+     * Найти элемент по имени и применить значение.
+     *
+     * @param {string} input_name
+     * @param {string} value
+     */
+    function applyOptionWithValue(input_name, value) {
+        $(`#topics_filter input[name='${input_name}']`).each(function() {
+            // Чекбоксы и радио могут иметь несколько выбранных значений.
+            if ($(this).is(':checkbox, :radio')) {
+                if (this.value === value) {
+                    $(this).prop('checked', true);
+                }
+            } else {
+                $(this).val(value);
+            }
+        });
+    }
+}
+
+/**
+ * Подсветить кнопки необходимости применения пресета.
+ *
+ * @param {boolean} display
+ */
+function toggleButtonUnsavedState(display) {
+    // Если пресет не выбран, то нет смысла подсвечивать кнопки.
+    if (!$('#preset_select').val() && display) {
+        return;
+    }
+
+    $('#preset_controls button.preset-unsaved').toggleClass('ui-state-error-text', display);
+}
+
+/**
+ * Открыть диалог управления пресетом (экспорт/импорт/сохранение)
+ */
+function openPresetDialog() {
+    const filter = getCurrentFilter();
+    const json = JSON.stringify(filter, null, 2);
+    const selectedName = $('#preset_select').val();
+
+    const buttons = [
+        {
+            text : 'Сохранить',
+            click: function() {
+                try {
+                    const name = $('#presetNameInput').val().trim();
+                    if (!name) {
+                        alert('Введите имя пресета!');
+
+                        return;
+                    }
+
+                    let filterText = $('#presetJsonArea').val();
+                    const filter = JSON.parse(filterText);
+
+                    filterText = JSON.stringify(filter);
+
+                    savePreset(name, filter);
+                    toggleButtonUnsavedState(false);
+                    loadSavedFilterOptions(filterText);
+
+                    // Вызываем применение фильтра.
+                    $('#topics_filter').trigger('manual_change');
+
+                    $dialog.dialog('close');
+                } catch (e) {
+                    alert('Ошибка парсинга JSON: ' + e.message);
+                }
+            }
+        },
+        {
+            text : 'Копировать JSON',
+            click: function() {
+                const text = $('#presetJsonArea').val();
+                copyToClipboard(text);
+                showResultTopics('JSON скопирован в буфер обмена');
+            }
+        },
+        {
+            text : 'Закрыть',
+            click: function() {
+                $(this).dialog('close');
+            }
+        },
+    ];
+
+    // Формируем HTML диалога
+    const $dialog = $('#dialog')
+        .html(`
+            <div style="margin-bottom:10px;">
+                <label for="presetNameInput">Имя пресета:</label>
+                <input id="presetNameInput" type="text" style="width:100%;" value="${selectedName || ''}" placeholder="Введите имя пресета" />
+            </div>
+            <div>
+                <label>JSON текущего фильтра:</label>
+                <textarea id="presetJsonArea" style="width:100%;height:250px;font-family:monospace;font-size:12px;">${json}</textarea>
+            </div>
+        `)
+        .dialog({
+            title  : 'Управление пресетом',
+            width  : 700,
+            modal  : true,
+            buttons: buttons,
+            open   : function() {
+                // При открытии фокусируем поле имени
+                $('#presetNameInput').focus();
+            }
+        })
+        .dialog('open');
+}

--- a/public/scripts/lib.topics.js
+++ b/public/scripts/lib.topics.js
@@ -165,7 +165,7 @@ function getFilteredTopics() {
     blockTopicsFilters(listingId);
 
     // Параметры фильтра в строку.
-    const $filter = $("#topics_filter").serializeJSON();
+    const $filter = $('#topics_filter').serializeSortedJSON();
     processStatus.set('Получение данных о раздачах...');
 
     $.ajax({
@@ -358,46 +358,4 @@ function execActionTopics(params) {
             }
         }
     });
-}
-
-// Обработать сохранённый набор фильтров вкладки "Раздачи".
-function loadSavedFilterOptions(filter_options) {
-    filter_options = $.parseJSON(filter_options);
-
-    $('#topics_filter input[type=radio], #topics_filter input[type=checkbox]').prop('checked', false);
-    $.each(filter_options, function (i, option) {
-        // Пропускаем "дату регистрации до".
-        if (option.name === 'filter_date_release') {
-            return true;
-        }
-
-        if ($(`#topics_filter [name='${option.name}']`).is("select")) {
-            $(`#${option.name}`).val(option.value).selectmenu("refresh");
-            return true;
-        }
-
-        $(`#topics_filter input[name='${option.name}']`).each(function () {
-            if (
-                $(this).attr("type") === "checkbox"
-                || $(this).attr("type") === "radio"
-            ) {
-                if ($(this).val() === option.value) {
-                    $(this).prop("checked", true);
-                }
-            } else if (this.name === option.name) {
-                $(this).val(option.value);
-            }
-        });
-    });
-
-    // FIXME !!!
-    if ($("#topics_filter [name=filter_interval]").prop("checked")) {
-        $(".filter_rule_interval, .filter_rule_one").toggle(500);
-    }
-    if ($("input[name=is_keepers]").prop("checked")) {
-        $(".keepers_filter_rule_fieldset").show();
-    }
-
-    // Обновить выбранные статусы хранения раздач.
-    $('.filter_status_controlgroup').controlgroup('refresh');
 }

--- a/public/scripts/module.jquery.methods.js
+++ b/public/scripts/module.jquery.methods.js
@@ -25,28 +25,15 @@ webtlo.register(ModuleNames.JQUERY_METHODS, function () {
             this.attr(`data-${key}`, data).data(key, data);
         }
 
-        // https://stackoverflow.com/questions/15958671/disabled-fields-not-picked-up-by-serializearray
-        $.fn.serializeAllArray = function () {
-            let data = $(this).serializeArray();
-            $(':disabled[name]', this).each(function () {
-                if (
-                    (
-                        $(this).attr('type') === 'checkbox'
-                        || $(this).attr('type') === 'radio'
-                    ) && !$(this).prop('checked')
-                ) {
-                    return true;
-                }
+        $.fn.serializeSortedJSON = function() {
+            const object = this.serializeJSON();
 
-                data.push(
-                    {
-                        name: this.name,
-                        value: $(this).val()
-                    }
-                );
-            });
-
-            return data;
+            return Object.keys(object)
+                .sort()
+                .reduce((Obj, key) => {
+                    Obj[key] = object[key];
+                    return Obj;
+                }, {});
         }
 
         /** Блокировка элемента + визуальное отображение */

--- a/public/scripts/module.topics.actions.js
+++ b/public/scripts/module.topics.actions.js
@@ -39,7 +39,7 @@ webtlo.register(ModuleNames.TOPICS_ACTIONS,function () {
             return;
         }
 
-        Cookies.set('filter-backup', $topicsFilter.serializeAllArray());
+        Cookies.set('filter-backup', getCurrentFilter());
 
         $("#topics_filter input[type=text]").val("");
         $("#topics_filter input[type=search]").val("");
@@ -59,6 +59,9 @@ webtlo.register(ModuleNames.TOPICS_ACTIONS,function () {
 
         // Обновить выбранные статусы хранения раздач.
         $('.filter_status_controlgroup').controlgroup('refresh');
+
+        // Сбросить выбранный пресет.
+        $('#preset_select').val('').selectmenu('refresh');
     });
 
     // Кнопки выделить все / отменить выделение.

--- a/public/scripts/module.topics.filters.js
+++ b/public/scripts/module.topics.filters.js
@@ -125,32 +125,31 @@ webtlo.register(ModuleNames.TOPICS_FILTERS, function() {
     });
 
 
-    let lastUsedFilter = '';
-
-    $topicsFilter.on('change input selectmenuchange spinstop', function(e) {
-        e.preventDefault();
-
-        // Текущий отсортированный набор фильтров.
-        const currentFilter = $topicsFilter.serializeAllArray().toSorted();
-        const currentFilterString = JSON.stringify(currentFilter);
-
-        // Если прошлый набор фильтров идентичен текущему - ничего не делаем.
-        if (lastUsedFilter === currentFilterString) {
-            return false;
+    $topicsFilter.on('change input selectmenuchange spinstop manual_change', function(e) {
+        // Пропускаем событие input, если элемент — чекбокс или радио.
+        if (e.type === 'input' && ($(e.target).is(':checkbox, :radio'))) {
+            return;
         }
 
-        // Запоминаем параметры фильтра в куки.
-        lastUsedFilter = currentFilterString;
-        Cookies.set('filter-options', currentFilter);
+        e.preventDefault();
 
+        // Если фильтр не изменился, то не применяем его автоматически.
+        if (!checkUsedFilterChange()) {
+            return;
+        }
+
+        // Если фильтр изменился (автоматически), подсвечиваем кнопки пресетов.
+        if (e.type !== 'manual_change') {
+            toggleButtonUnsavedState(true);
+        }
+
+        // Если включена опция "автоматически применять" - применяем.
         if ($('#enable_auto_apply_filter').prop('checked')) {
             filter_delay(function(){
                 clearLoadResult();
                 getFilteredTopics();
             }, window);
         }
-
-        return true;
     });
 
     // Скрываем прогресс загрузки.
@@ -164,6 +163,44 @@ webtlo.register(ModuleNames.TOPICS_FILTERS, function() {
         }
     });
 
+    // Пресет фильтров.
+    $('#preset_select').selectMenuWheel({
+        classes: {
+            'ui-selectmenu-menu': 'ui-menu-update-info'
+        },
+        select : (e, ui) => {
+            // При выборе нового элемента пресета, подсвечиваем кнопки, которые говорят о том, что его надо применить вручную.
+            toggleButtonUnsavedState(ui.item.index > 0);
+        }
+    });
+
+    // Кнопка показать/скрыть пресеты фильтров.
+    $('#preset_toggle').on('click', function () {
+        $('#preset_controls').toggle(500, function () {
+            Cookies.set('filter-preset-state', $(this).is(':visible'));
+        });
+    });
+
+    // Кнопки действия для пресетов.
+    $('#preset_apply').on('click', applySelectedPreset);
+    $('#preset_delete').on('click', deleteSelectedPreset);
+    $('#preset_save').on('click', function(e) {
+        if (e.ctrlKey || e.metaKey) {
+            // Ctrl+Click – открываем расширенный диалог.
+            e.preventDefault();
+            openPresetDialog();
+        } else {
+            // Обычный клик – сохранение пресета.
+            saveCurrentFilter();
+        }
+    });
+
+
+    // Загружаем пресеты.
+    loadPresetList();
+
+    // Состояние панели пресетов.
+    $('#preset_controls').toggle(Cookies.get('filter-preset-state') === 'true');
 
     // Загрузка параметров фильтра из cookie
     const filter_state = Cookies.get('filter-state');

--- a/public/scripts/module.topics.list.js
+++ b/public/scripts/module.topics.list.js
@@ -69,7 +69,7 @@ webtlo.register(ModuleNames.TOPICS_LIST, function() {
         $('input[name=filter_by_phrase][type="radio"]').prop('checked', false);
         $('#filter_by_keeper').prop('checked', true);
 
-        $('#topics_filter').change();
+        $('#topics_filter').trigger('manual_change');
     });
 
     // Поиск по торрент-клиенту при двойном клике по названию.
@@ -82,7 +82,7 @@ webtlo.register(ModuleNames.TOPICS_LIST, function() {
 
         $('#filter_client_id').val(torrentClientID).selectmenu('refresh');
 
-        $('#topics_filter').change();
+        $('#topics_filter').trigger('manual_change');
     });
 
     // очистка topics_result при изменениях на странице

--- a/public/scripts/module.topics.subsections.js
+++ b/public/scripts/module.topics.subsections.js
@@ -35,7 +35,9 @@ webtlo.register(ModuleNames.TOPICS_SUBSECTIONS, function() {
                 lastLoadedListing = savedForumId;
                 $(this).val(savedForumId).selectmenu('refresh')
 
-                loadFilteredTopics();
+                if (checkUsedFilterChange()) {
+                    loadFilteredTopics();
+                }
             }
         },
         open: function() {

--- a/src/back/Console/ConsoleCommand.php
+++ b/src/back/Console/ConsoleCommand.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace KeepersTeam\Webtlo\Console;
 
 use KeepersTeam\Webtlo\App;
+use KeepersTeam\Webtlo\Console\Topics\TopicsAdding;
+use KeepersTeam\Webtlo\Console\Topics\TopicsDownload;
 use KeepersTeam\Webtlo\Enum\LogFile;
 
 /**
@@ -23,29 +25,58 @@ enum ConsoleCommand: string
     case AdderReports = 'adder:reports';
     case AdderUpdate  = 'adder:update';
 
+    // Скачивание торрент-файлов.
+    case TopicsAdding   = 'topics:adding';
+    case TopicsDownload = 'topics:download';
+
     public function logFile(): LogFile
     {
         return match ($this) {
-            self::Control => LogFile::Control,
+            self::Control        => LogFile::Control,
             self::AdderKeepers,
-            self::Keepers => LogFile::Keepers,
+            self::Keepers        => LogFile::Keepers,
             self::AdderReports,
-            self::Reports => LogFile::Reports,
+            self::Reports        => LogFile::Reports,
             self::AdderUpdate,
-            self::Update  => LogFile::Update,
+            self::Update         => LogFile::Update,
+            self::TopicsAdding,
+            self::TopicsDownload => LogFile::Topics,
         };
     }
 
-    public function run(App $app): void
+    public function run(App $app, ConsoleInput $input): void
     {
         match ($this) {
-            self::Control => $app->get(CronControl::class)->run(),
+            self::Control        => $app->get(CronControl::class)->run(),
             self::AdderKeepers,
-            self::Keepers => $app->get(CronKeepers::class)->run(),
+            self::Keepers        => $app->get(CronKeepers::class)->run(),
             self::AdderReports,
-            self::Reports => $app->get(CronReports::class)->run(),
+            self::Reports        => $app->get(CronReports::class)->run(),
             self::AdderUpdate,
-            self::Update  => $app->get(CronUpdate::class)->run(),
+            self::Update         => $app->get(CronUpdate::class)->run(),
+            self::TopicsAdding   => $app->get(TopicsAdding::class)->run(input: $input),
+            self::TopicsDownload => $app->get(TopicsDownload::class)->run(input: $input),
+        };
+    }
+
+    /**
+     * @return array{}|string[]
+     */
+    public function arguments(): array
+    {
+        return match ($this) {
+            self::TopicsAdding   => [
+                'listingId',
+                'filterName',
+            ],
+
+            self::TopicsDownload => [
+                'listingId',
+                'filterName',
+                'replacePasskey',
+            ],
+
+            default              => [],
         };
     }
 }

--- a/src/back/Console/ConsoleInput.php
+++ b/src/back/Console/ConsoleInput.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KeepersTeam\Webtlo\Console;
+
+use RuntimeException;
+
+final class ConsoleInput
+{
+    /**
+     * @param array<string, string> $arguments
+     */
+    public function __construct(
+        public readonly array $arguments = [],
+    ) {}
+
+    /**
+     * @param literal-string $name
+     *
+     * @return non-empty-string
+     */
+    public function argument(string $name): string
+    {
+        if (!isset($this->arguments[$name]) || $this->arguments[$name] === '') {
+            throw new RuntimeException(
+                sprintf('Missing required argument: %s', $name)
+            );
+        }
+
+        return $this->arguments[$name];
+    }
+}

--- a/src/back/Console/ConsoleKernel.php
+++ b/src/back/Console/ConsoleKernel.php
@@ -66,7 +66,10 @@ final class ConsoleKernel
                 return 1;
             }
 
-            $command->run(app: $app);
+            $command->run(
+                app  : $app,
+                input: self::parseInput(command: $command, argv: $argv),
+            );
 
             return 0;
         } catch (RuntimeException $e) {
@@ -83,6 +86,30 @@ final class ConsoleKernel
             $lock->release();
             $logger->info('-- DONE --');
         }
+    }
+
+    /**
+     * @param string[] $argv
+     */
+    public static function parseInput(ConsoleCommand $command, array $argv): ConsoleInput
+    {
+        $argumentNames = $command->arguments();
+
+        $providedArguments = array_slice($argv, 2);
+
+        if (count($providedArguments) !== count($argumentNames)) {
+            throw new RuntimeException(
+                sprintf(
+                    'Command "%s" requires arguments: %s',
+                    $command->value,
+                    implode(' ', $argumentNames),
+                )
+            );
+        }
+
+        return new ConsoleInput(
+            arguments: array_combine($argumentNames, $providedArguments),
+        );
     }
 
     private function echoHelp(): void

--- a/src/back/Console/Topics/FilterTrait.php
+++ b/src/back/Console/Topics/FilterTrait.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KeepersTeam\Webtlo\Console\Topics;
+
+use KeepersTeam\Webtlo\Helper;
+use KeepersTeam\Webtlo\TopicList\ValidationException;
+use RuntimeException;
+
+trait FilterTrait
+{
+    /**
+     * @param non-empty-string $filterName
+     *
+     * @return array<string, mixed>
+     */
+    protected function getFilterPreset(string $filterName): array
+    {
+        $presetsFile = Helper::getStorageDir() . '/filter_presets.json';
+
+        // Чтение текущих пресетов.
+        $presets = [];
+        if (file_exists($presetsFile)) {
+            $presets = json_decode((string) file_get_contents($presetsFile), true);
+            if (!is_array($presets)) {
+                $presets = [];
+            }
+        }
+
+        $filter = [];
+        if (isset($presets[$filterName])) {
+            $filter = $presets[$filterName];
+        }
+
+        if (empty($filter) || !is_array($filter)) {
+            $this->logger->notice('Пресет фильтра не найден.', ['filterName' => $filterName]);
+
+            throw new RuntimeException("Пресет фильтра [$filterName] не найден");
+        }
+
+        $this->logger->debug('Пресет фильтра найден.', ['filterName' => $filterName, 'filter' => $filter]);
+
+        return $filter;
+    }
+
+    /**
+     * @param array<string, mixed> $filter
+     *
+     * @return string[]
+     */
+    protected function getTopicsHashes(int $listingId, array $filter): array
+    {
+        try {
+            $result = $this->listing->findTopics(listingId: $listingId, filter: $filter);
+        } catch (ValidationException $e) {
+            $this->logger->warning(
+                'Ошибка валидации фильтра',
+                ['error' => $e->getMessage(), 'class' => $e->getClass()]
+            );
+
+            throw new RuntimeException('Ошибка валидации фильтра.');
+        }
+
+        if (!count($result->groups)) {
+            throw new RuntimeException('Раздачи не найдены.');
+        }
+
+        $hashes = [];
+        foreach ($result->groups as $group) {
+            foreach ($group->topics as $topic) {
+                $hashes[] = $topic->topic->hash;
+            }
+        }
+
+        return array_values(array_unique($hashes));
+    }
+}

--- a/src/back/Console/Topics/TopicsAdding.php
+++ b/src/back/Console/Topics/TopicsAdding.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KeepersTeam\Webtlo\Console\Topics;
+
+use KeepersTeam\Webtlo\Action\ClientAddTopics;
+use KeepersTeam\Webtlo\Console\ConsoleInput;
+use KeepersTeam\Webtlo\TopicList\TopicListing;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Поиск раздач по имени пресета фильтра.
+ * Скачивание торрент-файлов по хешам найденных раздач.
+ * Добавление торрент-файлов в торрент-клиенты.
+ */
+final class TopicsAdding
+{
+    use FilterTrait;
+
+    public function __construct(
+        private readonly TopicListing    $listing,
+        private readonly ClientAddTopics $addClient,
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    public function run(ConsoleInput $input): void
+    {
+        $listingId  = (int) $input->argument(name: 'listingId');
+        $filterName = $input->argument(name: 'filterName');
+
+        $this->logger->info(
+            'Начинаем автоматическое добавление раздач в торрент-клиенты.',
+            ['listingId' => $listingId, 'filterName' => $filterName]
+        );
+
+        // Ищем пресет фильтра по имени.
+        $filter = $this->getFilterPreset(filterName: $filterName);
+
+        // Ищем хеши раздач с использованием пресета.
+        $hashes = $this->getTopicsHashes(listingId: $listingId, filter: $filter);
+
+        $this->logger->info(
+            'С помощью фильтра найдено {count} раздач. Начинаем добавление в торрент-клиенты...',
+            ['count' => count($hashes)]
+        );
+
+        $this->addClient->process(hashes: $hashes);
+    }
+}

--- a/src/back/Console/Topics/TopicsDownload.php
+++ b/src/back/Console/Topics/TopicsDownload.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KeepersTeam\Webtlo\Console\Topics;
+
+use KeepersTeam\Webtlo\Action\TopicDownload;
+use KeepersTeam\Webtlo\Console\ConsoleInput;
+use KeepersTeam\Webtlo\TopicList\TopicListing;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Поиск раздач по имени пресета фильтра.
+ * Скачивание торрент-файлов по хешам найденных раздач.
+ * Запись торрент-файлов в каталог, указанный в настройках.
+ */
+final class TopicsDownload
+{
+    use FilterTrait;
+
+    public function __construct(
+        private readonly TopicListing    $listing,
+        private readonly TopicDownload   $download,
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    public function run(ConsoleInput $input): void
+    {
+        $listingId      = (int) $input->argument(name: 'listingId');
+        $filterName     = $input->argument(name: 'filterName');
+        $replacePasskey = (bool) $input->argument(name: 'replacePasskey');
+
+        $this->logger->info(
+            'Начинаем автоматическое скачивание торрент-файлов раздач.',
+            ['listingId' => $listingId, 'filterName' => $filterName]
+        );
+
+        // Ищем пресет фильтра по имени.
+        $filter = $this->getFilterPreset(filterName: $filterName);
+
+        // Ищем хеши раздач с использованием пресета.
+        $hashes = $this->getTopicsHashes(listingId: $listingId, filter: $filter);
+
+        $this->logger->info(
+            'С помощью фильтра найдено {count} раздач. Начинаем скачивание торрент-файлов...',
+            ['count' => count($hashes)]
+        );
+
+        $this->download->process(listingId: $listingId, hashes: $hashes, replacePasskey: $replacePasskey);
+    }
+}

--- a/src/back/Enum/LogFile.php
+++ b/src/back/Enum/LogFile.php
@@ -23,6 +23,7 @@ enum LogFile: string
     case Keepers = 'keepers';
     case Reports = 'reports';
     case Control = 'control';
+    case Topics  = 'topics';
 
     public function getFileName(): string
     {


### PR DESCRIPTION
1. В панель управления раздачами и фильтрами добавлен новый блок управления пресетами (скрыт по умолчанию)
close #193

<img width="1201" height="108" alt="image" src="https://github.com/user-attachments/assets/cd115c7f-318f-4ed0-95fd-2848c68aff9f" />
<img width="502" height="126" alt="image" src="https://github.com/user-attachments/assets/41d39591-9043-49b2-ab1f-51f38d39511a" />

С кнопками:
- применить - применяет сохранённый пресет фильтров к форме ввода и записывает его в "последний использованный"; если включена опция "применять фильтр автоматически" - то список раздач будет загружен автоматически при применении пресета, если нет, то нужно нажать ещё одну галку применения уже фильтра
- сохранить - нажатие - сохраняет или пересохраняет текущий набор фильтров с текущим именем или предлагает ввести новое; Ctrl+Click - откроет дополнительное окно управления;
- удалить - удаляет текущий пресет.

При изменении параметров фильтра вручную и при открытой панели пресетов, кнопки приенения и сохранения будут подсвечены, пока не применить пресет (перезаписать фильтры) или не сохранить пресет (перезаписать его).

Дополнительное окно:
<img width="906" height="649" alt="image" src="https://github.com/user-attachments/assets/4cadd1b3-a503-44e3-91f1-c3f9efbfe8ce" />
Позволяет скопировать текущий набор фильтров для любых целей; отредактировать поля вручную; импортировать из других мест.
Набор фильтров можно сохранить с желаемым именем.


2. В бинарник (bin/webtlo) добавлены новые методы:
 - `topics:adding [(int)listingId (string)presetName]`
 - `topics:download [(int)listingId (string)presetName (bool)replacePassKey]`
close #117
close #216 

Которые позволяют добавлять в клиент или скачивать файлы по заранее сохранённому пресету фильтров и ид подраздела в соответствии с прочими настройками.

Например, создаём пресет фильтров, даём ему имя "cron-example", вызываем из консоли что-то такое:
`bin/webtlo topics:adding 357 cron-example`

Раздачи из 357 подраздела будут отфильтрованы пресетом и добавлены в клиент согласно настройкам этого хранимого подраздела (каталог, клиент, метки, etc).

`listingId` - может быть в т.ч. ид особого разворота, см таблицу в #604 

Загрузка файлов аналогично
`bin/webtlo topics:download 357 cron-example false`
Отфильтрует и скачает файлы в каталог, который указан в настройках

