### PR TITLE
Console. Use actual hash for unregistered topics

### DIFF
--- a/src/back/Console/Topics/FilterTrait.php
+++ b/src/back/Console/Topics/FilterTrait.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace KeepersTeam\Webtlo\Console\Topics;
 
 use KeepersTeam\Webtlo\Helper;
+use KeepersTeam\Webtlo\TopicList\ListingType;
 use KeepersTeam\Webtlo\TopicList\ValidationException;
 use RuntimeException;
 
@@ -66,9 +67,21 @@ trait FilterTrait
             throw new RuntimeException('Раздачи не найдены.');
         }
 
-        $hashes = [];
+        $hashes      = [];
+        $listingType = ListingType::tryFallBack($listingId);
         foreach ($result->groups as $group) {
             foreach ($group->topics as $topic) {
+                if ($listingType === ListingType::Unregistered) {
+                    $updatedHash = $topic->details['updated_hash'] ?? null;
+                    if (!is_string($updatedHash) || $updatedHash === '') {
+                        continue;
+                    }
+
+                    $hashes[] = $updatedHash;
+
+                    continue;
+                }
+
                 $hashes[] = $topic->topic->hash;
             }
         }

--- a/src/back/Console/Topics/FilterTrait.php
+++ b/src/back/Console/Topics/FilterTrait.php
@@ -70,10 +70,21 @@ trait FilterTrait
         $hashes      = [];
         $listingType = ListingType::tryFallBack($listingId);
         foreach ($result->groups as $group) {
+            if (
+                $listingType === ListingType::Unregistered
+                && (!is_string($group->key) || !str_starts_with($group->key, 'обновлено ('))
+            ) {
+                continue;
+            }
+
             foreach ($group->topics as $topic) {
                 if ($listingType === ListingType::Unregistered) {
                     $updatedHash = $topic->details['updated_hash'] ?? null;
-                    if (!is_string($updatedHash) || $updatedHash === '') {
+                    if (
+                        !is_string($updatedHash)
+                        || $updatedHash === ''
+                        || $updatedHash === $topic->topic->hash
+                    ) {
                         continue;
                     }
 

--- a/src/back/Console/Topics/FilterTrait.php
+++ b/src/back/Console/Topics/FilterTrait.php
@@ -46,7 +46,8 @@ trait FilterTrait
     }
 
     /**
-     * @param array<string, mixed> $filter
+     * @param int                  $listingId ид подраздела или ид "разворота" раздач
+     * @param array<string, mixed> $filter    параметры фильтра для поиска раздач
      *
      * @return string[]
      */
@@ -67,9 +68,15 @@ trait FilterTrait
             throw new RuntimeException('Раздачи не найдены.');
         }
 
-        $hashes      = [];
+        $hashes = [];
+
         $listingType = ListingType::tryFallBack($listingId);
         foreach ($result->groups as $group) {
+            /**
+             * Для разворота "незарегистрированные" используем только хеши раздач, которые имеют новую версию.
+             *
+             * @TODO Переделать таблицу хранения разрегов и завести ид вместо текста статусов.
+             */
             if (
                 $listingType === ListingType::Unregistered
                 && (!is_string($group->key) || !str_starts_with($group->key, 'обновлено ('))


### PR DESCRIPTION
## Что изменено

- для списка незарегистрированных раздач команда `topics:adding` использует хеш актуальной версии раздачи;
- автоматически обрабатываются только группы `обновлено (...)` — диагностические группы `закрыто (...)` пропускаются;
- раздачи без хеша актуальной версии и раздачи, у которых новый хеш совпадает со старым, пропускаются;
- для остальных типов списков существующая логика выбора хеша не меняется.

## Зачем

Интерфейс webTLO уже подставляет `updated_hash` для выбранных пользователем незарегистрированных раздач перед скачиванием или добавлением в торрент-клиент. Консольная команда при этом продолжала брать исходный хеш из `Topic`, поэтому `topics:adding -31 <имя-пресета>` передавала устаревший хеш в `ClientAddTopics`, который ищет только актуальные хеши в таблице `Topics`.

Список `-31` содержит не только доступные для обновления раздачи, но и диагностические группы `закрыто (...)`. В интерфейсе пользователь выбирает строки вручную, а консольная команда выполняется автоматически, поэтому она ограничена группами `обновлено (...)`.

Изменение позволяет безопасно запускать автоматическое обновление по расписанию после `cron:update`.

## Проверка

- `git diff --check`;
- PHP 8.1–8.5: PHP-CS-Fixer и PHPStan — успешно;
- проверка YAML и зависимостей — успешно.
