### PR TITLE
Console. Parse replacePasskey as boolean

### DIFF
--- a/src/back/Console/ConsoleInput.php
+++ b/src/back/Console/ConsoleInput.php
@@ -49,4 +49,23 @@ final class ConsoleInput
 
         return $value;
     }
+
+    /**
+     * @param literal-string $name
+     */
+    public function booleanArgument(string $name): bool
+    {
+        $value = filter_var(
+            $this->argument($name),
+            FILTER_VALIDATE_BOOL,
+            FILTER_NULL_ON_FAILURE,
+        );
+        if (!is_bool($value)) {
+            throw new RuntimeException(
+                sprintf('Invalid boolean argument: %s', $name)
+            );
+        }
+
+        return $value;
+    }
 }

--- a/src/back/Console/Topics/TopicsDownload.php
+++ b/src/back/Console/Topics/TopicsDownload.php
@@ -28,7 +28,7 @@ final class TopicsDownload
     {
         $listingId      = $input->integerArgument(name: 'listingId');
         $filterName     = $input->argument(name: 'filterName');
-        $replacePasskey = (bool) $input->argument(name: 'replacePasskey');
+        $replacePasskey = $input->booleanArgument(name: 'replacePasskey');
 
         $this->logger->info(
             'Начинаем автоматическое скачивание торрент-файлов раздач.',


### PR DESCRIPTION
## Что изменено

- аргумент `replacePasskey` команды `topics:download` разбирается как логическое значение, а не приводится из непустой строки к `bool`;
- поддерживаются стандартные значения `true/1/on/yes` и `false/0/off/no` без учёта регистра;
- для некорректного значения команда завершается с понятной ошибкой.

## Зачем

Аргументы CLI передаются строками, а в PHP любая непустая строка, кроме `"0"`, при приведении к `bool` даёт `true`. Поэтому документированный вызов:

```shell
bin/webtlo topics:download 357 cron-example false
```

фактически включал замену passkey.

Изменение касается только аргумента `replacePasskey` консольной команды `topics:download`. Обработка JSON-boolean из интерфейса и остальные команды не меняются.

## Проверка

- `git diff --check`;
- PHP 8.1–8.5: PHP-CS-Fixer и PHPStan — успешно;
- проверка YAML и зависимостей — успешно.
