### PR TITLE
Console. Validate listingId argument

### DIFF
--- a/src/back/Console/ConsoleInput.php
+++ b/src/back/Console/ConsoleInput.php
@@ -30,4 +30,23 @@ final class ConsoleInput
 
         return $this->arguments[$name];
     }
+
+    /**
+     * @param literal-string $name
+     */
+    public function integerArgument(string $name): int
+    {
+        $value = filter_var(
+            $this->argument($name),
+            FILTER_VALIDATE_INT,
+            FILTER_NULL_ON_FAILURE,
+        );
+        if (!is_int($value)) {
+            throw new RuntimeException(
+                sprintf('Invalid integer argument: %s', $name)
+            );
+        }
+
+        return $value;
+    }
 }

--- a/src/back/Console/Topics/TopicsAdding.php
+++ b/src/back/Console/Topics/TopicsAdding.php
@@ -26,7 +26,7 @@ final class TopicsAdding
 
     public function run(ConsoleInput $input): void
     {
-        $listingId  = (int) $input->argument(name: 'listingId');
+        $listingId  = $input->integerArgument(name: 'listingId');
         $filterName = $input->argument(name: 'filterName');
 
         $this->logger->info(

--- a/src/back/Console/Topics/TopicsDownload.php
+++ b/src/back/Console/Topics/TopicsDownload.php
@@ -26,7 +26,7 @@ final class TopicsDownload
 
     public function run(ConsoleInput $input): void
     {
-        $listingId      = (int) $input->argument(name: 'listingId');
+        $listingId      = $input->integerArgument(name: 'listingId');
         $filterName     = $input->argument(name: 'filterName');
         $replacePasskey = (bool) $input->argument(name: 'replacePasskey');
 


### PR DESCRIPTION
## Что изменено

- в `ConsoleInput` добавлено типизированное чтение целочисленных аргументов;
- команды `topics:adding` и `topics:download` валидируют `listingId` до преобразования типа;
- нечисловые, дробные и выходящие за диапазон `int` значения завершают команду с понятной ошибкой.

## Зачем

Аргументы CLI передаются строками. Прямое приведение строки к `int` могло незаметно превратить ошибочное значение в допустимый идентификатор:

```text
abc    -> 0   -> OtherSubForums
357abc -> 357 -> подраздел 357
-31x   -> -31 -> Unregistered
```

В результате команда добавления или скачивания могла обработать другой список раздач вместо отказа.

Положительные ID подразделов, актуальные отрицательные ID разворотов и legacy-значения, включая `0` и `-1`, продолжают поддерживаться.

Изменение касается только аргумента `listingId` консольных команд `topics:adding` и `topics:download`. UI и остальные команды не меняются.

## Проверка

- `git diff --check`;
- PHP 8.1–8.5: PHP-CS-Fixer и PHPStan — успешно;
- проверка YAML и зависимостей — успешно.
