### PR TITLE
Logging. Remove secrets from log context

### DIFF
--- a/src/back/Action/TopicDownload.php
+++ b/src/back/Action/TopicDownload.php
@@ -43,7 +43,7 @@ final class TopicDownload
             $forRegularUser ? 'пользовательские' : 'хранительские'
         );
         if ($replacePasskey) {
-            $log_string .= !empty($passkeyValue) ? "Замена Passkey: [$passkeyValue]" : 'Passkey пуст.';
+            $log_string .= !empty($passkeyValue) ? 'Замена Passkey включена.' : 'Passkey пуст.';
         }
 
         $this->logger->info($log_string);

--- a/src/back/Clients/Flood.php
+++ b/src/back/Clients/Flood.php
@@ -321,7 +321,7 @@ final class Flood implements ClientInterface
     {
         $sid = $this->jar->getCookieByName('jwt');
         if ($sid !== null) {
-            $this->logger->debug('Got flood auth token', $sid->toArray());
+            $this->logger->debug('Got flood auth token');
 
             return true;
         }

--- a/src/back/Clients/Qbittorrent.php
+++ b/src/back/Clients/Qbittorrent.php
@@ -340,8 +340,8 @@ final class Qbittorrent implements ClientInterface
         // Если какой-то иной статус, прекращаем.
         if ($cookieName === null) {
             $this->logger->debug('Unhandled qbittorrent auth status', [
-                'status' => $statusCode,
-                'cookie' => $response->getHeader('set-cookie'),
+                'status'              => $statusCode,
+                'auth_cookie_present' => $response->hasHeader('set-cookie'),
             ]);
 
             return false;
@@ -349,7 +349,7 @@ final class Qbittorrent implements ClientInterface
 
         $cookie = $this->jar->getCookieByName(name: $cookieName);
         if ($cookie !== null) {
-            $this->logger->debug('Got qbittorrent auth token', $cookie->toArray());
+            $this->logger->debug('Got qbittorrent auth token');
 
             return true;
         }

--- a/src/back/Clients/Transmission.php
+++ b/src/back/Clients/Transmission.php
@@ -423,7 +423,7 @@ final class Transmission implements ClientInterface
 
                 // Записываем токен авторизации в заголовки.
                 $headers[$tokenName] = $sid;
-                $logger->debug('Got transmission auth token', [$sid]);
+                $logger->debug('Got transmission auth token');
             }
         };
     }

--- a/src/back/External/ForumClient.php
+++ b/src/back/External/ForumClient.php
@@ -118,7 +118,10 @@ final class ForumClient
             $this->logger->debug('Downloading torrent', ['hash' => $infoHash]);
             $response = $this->client->get(self::torrentUrl, $options);
         } catch (GuzzleException $e) {
-            $this->logger->error('Failed to download torrent', ['hash' => $infoHash, 'error' => $e]);
+            $this->logger->error('Failed to download torrent', [
+                'hash' => $infoHash,
+                'code' => $e->getCode(),
+            ]);
 
             return null;
         }

--- a/src/back/External/Shared/RetryMiddleware.php
+++ b/src/back/External/Shared/RetryMiddleware.php
@@ -47,7 +47,7 @@ trait RetryMiddleware
             ]);
 
             $logger->debug('Retrying request', [
-                'url'     => $request->getUri()->__toString(),
+                'url'     => $request->getUri()->getPath(),
                 'delay'   => $delay,
                 'attempt' => $attempt,
                 'reason'  => $reason,


### PR DESCRIPTION
## Что изменено

- значение passkey больше не записывается при скачивании торрент-файлов;
- auth-cookie qBittorrent, JWT Flood и session ID Transmission исключены из debug-контекста;
- при неожиданном ответе qBittorrent логируется только наличие `Set-Cookie`, но не его содержимое;
- повторные HTTP-запросы логируют только путь без query-параметров;
- ошибка скачивания торрента больше не сериализует исключение с полным URL запроса.

Сообщения об успешной авторизации, коды ошибок, HTTP-статусы, путь запроса и факт включённой замены passkey остаются доступными для диагностики.

## Зачем

Основной `webtlo.log` принимает в том числе debug-сообщения. В него могли попасть:

- пользовательский passkey;
- токены сессий торрент-клиентов;
- заголовок `Set-Cookie`;
- `keeper_api_key` из query-параметров URL скачивания.

Эти значения позволяют повтор или повторно использовать авторизованную сессию и не должны сохраняться в журнале.

Изменение предотвращает новые записи секретов. Уже существующие и ротированные файлы журналов автоматически не изменяются.

## Проверка

- `git diff --check`;
- PHP 8.1–8.5: PHP-CS-Fixer и PHPStan — успешно;
- проверка YAML и зависимостей — успешно.
