### PR TITLE
Корректно определять полную загрузку в qBittorrent

### DIFF
--- a/src/back/Clients/Qbittorrent.php
+++ b/src/back/Clients/Qbittorrent.php
@@ -559,12 +559,7 @@ final class Qbittorrent implements ClientInterface
             $trackerError  = null;
 
             // Процент загрузки торрента.
-            $progress = $torrent['progress'];
-            if ($progress === 1 && !empty($torrent['availability'])) {
-                if ($torrent['availability'] > 0 && $torrent['availability'] < 1) {
-                    $progress = (float) $torrent['availability'];
-                }
-            }
+            $progress = $this->getTorrentProgress(torrent: $torrent, clientHash: $clientHash);
 
             // Получение ошибок трекера.
             if ($callback !== null) {
@@ -649,6 +644,45 @@ final class Qbittorrent implements ClientInterface
         );
 
         return Helper::convertKeysToString(array: $properties);
+    }
+
+    /**
+     * qBittorrent считает progress только по выбранным файлам. Если size меньше
+     * total_size (пропущенные файлы или padding), проверяем локальные части,
+     * а не доступность частей в сети.
+     *
+     * @param array<string, mixed> $torrent
+     */
+    private function getTorrentProgress(array $torrent, string $clientHash): float
+    {
+        $progress = (float) $torrent['progress'];
+        if ($progress !== 1.0 || (int) $torrent['size'] >= (int) $torrent['total_size']) {
+            return $progress;
+        }
+
+        $piecesHave = $torrent['pieces_have'] ?? null;
+        $piecesNum  = $torrent['pieces_num'] ?? null;
+        if ($piecesHave === null || $piecesNum === null) {
+            // В старых версиях qBittorrent этих полей нет в torrents/info.
+            try {
+                $properties = $this->getProperties(torrentHash: $clientHash);
+            } catch (RuntimeException) {
+                // Дополнительный запрос не должен прерывать обновление списка раздач.
+                return $progress;
+            }
+
+            $piecesHave = $properties['pieces_have'] ?? null;
+            $piecesNum  = $properties['pieces_num'] ?? null;
+        }
+
+        if (
+            is_int($piecesHave) && is_int($piecesNum)
+            && $piecesNum > 0 && $piecesHave >= 0 && $piecesHave <= $piecesNum
+        ) {
+            return $piecesHave / $piecesNum;
+        }
+
+        return $progress;
     }
 
     private function checkLabelExists(string $labelName = ''): void

--- a/src/back/Clients/Qbittorrent.php
+++ b/src/back/Clients/Qbittorrent.php
@@ -559,7 +559,7 @@ final class Qbittorrent implements ClientInterface
             $trackerError  = null;
 
             // Процент загрузки торрента.
-            $progress = $this->getTorrentProgress(torrent: $torrent, clientHash: $clientHash);
+            $progress = $this->getTorrentProgress(torrent: $torrent);
 
             // Получение ошибок трекера.
             if ($callback !== null) {
@@ -647,39 +647,30 @@ final class Qbittorrent implements ClientInterface
     }
 
     /**
-     * qBittorrent считает progress только по выбранным файлам. Если size меньше
-     * total_size (пропущенные файлы или padding), проверяем локальные части,
-     * а не доступность частей в сети.
+     * qBittorrent считает progress только по выбранным файлам. Начиная с 5.2.0
+     * torrents/info содержит число загруженных и всех частей. Для старых версий
+     * сохраняем прежнюю оценку по availability.
      *
      * @param array<string, mixed> $torrent
      */
-    private function getTorrentProgress(array $torrent, string $clientHash): float
+    private function getTorrentProgress(array $torrent): float
     {
         $progress = (float) $torrent['progress'];
-        if ($progress !== 1.0 || (int) $torrent['size'] >= (int) $torrent['total_size']) {
+        if ($progress !== 1.0) {
             return $progress;
         }
 
         $piecesHave = $torrent['pieces_have'] ?? null;
         $piecesNum  = $torrent['pieces_num'] ?? null;
-        if ($piecesHave === null || $piecesNum === null) {
-            // В старых версиях qBittorrent этих полей нет в torrents/info.
-            try {
-                $properties = $this->getProperties(torrentHash: $clientHash);
-            } catch (RuntimeException) {
-                // Дополнительный запрос не должен прерывать обновление списка раздач.
-                return $progress;
-            }
-
-            $piecesHave = $properties['pieces_have'] ?? null;
-            $piecesNum  = $properties['pieces_num'] ?? null;
-        }
-
         if (
             is_int($piecesHave) && is_int($piecesNum)
             && $piecesNum > 0 && $piecesHave >= 0 && $piecesHave <= $piecesNum
         ) {
             return $piecesHave / $piecesNum;
+        }
+
+        if (!empty($torrent['availability']) && $torrent['availability'] > 0 && $torrent['availability'] < 1) {
+            return (float) $torrent['availability'];
         }
 
         return $progress;


### PR DESCRIPTION
## Что изменено

- Убрана подмена прогресса загрузки значением availability: оно описывает доступность частей у пиров, а не локальные данные.
- Если qBittorrent сообщает progress = 1 при size < total_size, полнота раздачи уточняется по локальным pieces_have / pieces_num. Это покрывает раздачи с отключёнными файлами и не путает их с полностью скачанными гибридными/v2-раздачами с padding.
- В новых версиях поля берутся из torrents/info; в старых — из torrents/properties. Если дополнительный запрос не удался, сохраняется исходный progress и обновление списка не прерывается.

## Проверка

- git diff --check — без ошибок.
- Локально PHP и Composer недоступны; проверки php-cs-fixer и PHPStan остаются за CI.