### PR TITLE
Обновлять отчёты хранителей транзакционно по подразделам

### DIFF
--- a/src/back/Storage/Clone/KeepersLists.php
+++ b/src/back/Storage/Clone/KeepersLists.php
@@ -6,9 +6,7 @@ namespace KeepersTeam\Webtlo\Storage\Clone;
 
 use KeepersTeam\Webtlo\Data\Keeper;
 use KeepersTeam\Webtlo\External\Data\KeptTopic;
-use KeepersTeam\Webtlo\Infrastructure\Database\ConnectionInterface;
 use KeepersTeam\Webtlo\Storage\CloneTable;
-use Psr\Log\LoggerInterface;
 
 /**
  * Временная таблица содержащая данные о хранителях и их хранимых раздачах, по данным API отчётов.
@@ -29,11 +27,7 @@ final class KeepersLists
     /** @var array<int, mixed>[] */
     private array $keptTopics = [];
 
-    public function __construct(
-        private readonly ConnectionInterface $db,
-        private readonly LoggerInterface     $logger,
-        private readonly CloneTable          $clone,
-    ) {}
+    public function __construct(private readonly CloneTable $clone) {}
 
     /**
      * @param KeptTopic[] $topics
@@ -64,33 +58,20 @@ final class KeepersLists
         $this->keptTopics = [];
     }
 
-    /**
-     * Перенести данные о хранимых раздачах в основную таблицу БД.
-     */
-    public function moveToOrigin(int $forumsScanned, int $keepersCount): void
+    public function clearTempTable(): void
     {
-        $tab = $this->clone;
-
-        $keepersSeedersCount = $tab->cloneCount();
-        if ($keepersSeedersCount > 0) {
-            $this->logger->info('Подразделов: {forums} шт, хранителей: {keepers}, хранимых раздач: {topics} шт.', [
-                'forums'  => $forumsScanned,
-                'keepers' => $keepersCount,
-                'topics'  => $keepersSeedersCount,
-            ]);
-            $this->logger->info('KeepersLists. Запись в базу данных списков раздач хранителей...');
-
-            $tab->moveToOrigin();
-
-            // Удаляем неактуальные записи списков.
-            $tab->removeUnusedKeepersRows();
-
-            $this->logger->info('KeepersLists. Записано {topics} хранимых раздач.', ['topics' => $keepersSeedersCount]);
-        }
+        $this->clone->clearClone();
+        $this->keptTopics = [];
     }
 
-    public function clearLists(): void
+    /**
+     * Заменить данные подраздела в основной таблице БД.
+     */
+    public function replaceForum(int $forumId): int
     {
-        $this->db->executeStatement('DELETE FROM UpdateTime WHERE id BETWEEN 100000 AND 200000');
+        $count = $this->clone->cloneCount();
+        $this->clone->replaceKeepersRows(forumId: $forumId);
+
+        return $count;
     }
 }

--- a/src/back/Storage/Clone/KeepersSeeders.php
+++ b/src/back/Storage/Clone/KeepersSeeders.php
@@ -7,7 +7,6 @@ namespace KeepersTeam\Webtlo\Storage\Clone;
 use KeepersTeam\Webtlo\Data\Keeper;
 use KeepersTeam\Webtlo\External\Data\KeptTopic;
 use KeepersTeam\Webtlo\Storage\CloneTable;
-use Psr\Log\LoggerInterface;
 
 /**
  * Временная таблица содержащая данные о хранителях и сидируемых ими раздачах, по данным API форума.
@@ -26,10 +25,7 @@ final class KeepersSeeders
     /** @var array<int, mixed>[] */
     private array $keptTopics = [];
 
-    public function __construct(
-        private readonly LoggerInterface $logger,
-        private readonly CloneTable      $clone,
-    ) {}
+    public function __construct(private readonly CloneTable $clone) {}
 
     /**
      * Записать хранителя, если он сидирует раздачу.
@@ -65,25 +61,20 @@ final class KeepersSeeders
         $this->keptTopics = [];
     }
 
-    /**
-     * Перенести данные о хранимых раздачах в основную таблицу БД.
-     */
-    public function moveToOrigin(): void
+    public function clearTempTable(): void
     {
-        $tab = $this->clone;
+        $this->clone->clearClone();
+        $this->keptTopics = [];
+    }
 
-        $keepersSeedersCount = $tab->cloneCount();
-        if ($keepersSeedersCount > 0) {
-            $this->logger->info('KeepersSeeders. Запись в базу данных списка сидов-хранителей...');
-            $tab->moveToOrigin();
+    /**
+     * Заменить данные подраздела в основной таблице БД.
+     */
+    public function replaceForum(int $forumId): int
+    {
+        $count = $this->clone->cloneCount();
+        $this->clone->replaceKeepersRows(forumId: $forumId);
 
-            // Удалить ненужные записи.
-            $tab->removeUnusedKeepersRows();
-
-            $this->logger->info(
-                'KeepersSeeders. Хранителями раздаётся {topics} неуникальных раздач.',
-                ['topics' => $keepersSeedersCount]
-            );
-        }
+        return $count;
     }
 }

--- a/src/back/Storage/CloneFactory.php
+++ b/src/back/Storage/CloneFactory.php
@@ -62,9 +62,7 @@ final class CloneFactory
         );
 
         return new KeepersLists(
-            db    : $this->con,
-            logger: $this->logger,
-            clone : $table,
+            clone: $table,
         );
     }
 
@@ -77,8 +75,7 @@ final class CloneFactory
         );
 
         return new KeepersSeeders(
-            logger: $this->logger,
-            clone : $table,
+            clone: $table,
         );
     }
 

--- a/src/back/Storage/CloneTable.php
+++ b/src/back/Storage/CloneTable.php
@@ -146,24 +146,36 @@ final class CloneTable
     }
 
     /**
-     * Удалить ненужные строки о хранимых раздачах хранителей.
+     * Заменить данные хранителей для известных тем указанного подраздела.
      *
      * Актуально только для KeepersLists и KeepersSeeders.
+     * Новые темы без строки в Topics тоже сохраняются до обновления списка тем.
+     * Вызывать внутри транзакции вместе с обновлением второй таблицы и маркера.
      */
-    public function removeUnusedKeepersRows(): void
+    public function replaceKeepersRows(int $forumId): void
     {
         $tab = $this->table;
+        $keys = implode(', ', array_map(static fn(string $key) => "tmp.$key", $tab->keys));
+        $insertKeys = $tab->getKeysInsert();
 
         $this->con->executeStatement(
             "
                 DELETE FROM $tab->origin
-                WHERE topic_id || keeper_id NOT IN (
-                    SELECT upd.topic_id || upd.keeper_id
-                    FROM $tab->clone AS tmp
-                    LEFT JOIN $tab->origin AS upd ON tmp.topic_id = upd.topic_id AND tmp.keeper_id = upd.keeper_id
-                    WHERE upd.topic_id IS NOT NULL
-                )
+                WHERE topic_id IN (SELECT id FROM Topics WHERE forum_id = ?)
+            ",
+            [$forumId]
+        );
+
+        // Темы без строки в Topics оставляем до обновления списка тем.
+        // Известные темы другого подраздела отчёт менять не должен.
+        $this->con->executeStatement(
             "
+                INSERT INTO $tab->origin $insertKeys
+                SELECT $keys FROM $tab->clone AS tmp
+                LEFT JOIN Topics AS topic ON topic.id = tmp.topic_id
+                WHERE topic.forum_id = ? OR topic.forum_id IS NULL
+            ",
+            [$forumId]
         );
     }
 

--- a/src/back/Storage/CloneTable.php
+++ b/src/back/Storage/CloneTable.php
@@ -154,8 +154,8 @@ final class CloneTable
      */
     public function replaceKeepersRows(int $forumId): void
     {
-        $tab = $this->table;
-        $keys = implode(', ', array_map(static fn(string $key) => "tmp.$key", $tab->keys));
+        $tab        = $this->table;
+        $keys       = implode(', ', array_map(static fn(string $key) => "tmp.$key", $tab->keys));
         $insertKeys = $tab->getKeysInsert();
 
         $this->con->executeStatement(

--- a/src/back/Update/KeepersReports.php
+++ b/src/back/Update/KeepersReports.php
@@ -56,7 +56,7 @@ final class KeepersReports
         $this->logger->info('ApiReport. Начато обновление отчётов хранителей...');
 
         // Список ид обновлений подразделов.
-        $keptForumsUpdate = array_map(static fn($el) => 100000 + $el, $keptForums);
+        $keptForumsUpdate   = array_map(static fn($el) => 100000 + $el, $keptForums);
         $keptForumsUpdate[] = UpdateMark::KEEPERS->value;
 
         $updateStatus = $this->updateTime->getMarkersObject(markers: $keptForumsUpdate);
@@ -155,7 +155,7 @@ final class KeepersReports
 
             try {
                 $this->db->beginTransaction();
-                $listsCount = $this->keepersLists->replaceForum(forumId: $forumId);
+                $listsCount   = $this->keepersLists->replaceForum(forumId: $forumId);
                 $seedersCount = $this->keepersSeeders->replaceForum(forumId: $forumId);
                 $this->updateTime->setMarkerTime(marker: 100000 + $forumId);
                 $this->db->commitTransaction();

--- a/src/back/Update/KeepersReports.php
+++ b/src/back/Update/KeepersReports.php
@@ -11,6 +11,7 @@ use KeepersTeam\Webtlo\Enum\UpdateStatus;
 use KeepersTeam\Webtlo\External\ApiReportClient;
 use KeepersTeam\Webtlo\External\Data\ApiError;
 use KeepersTeam\Webtlo\External\Data\KeepersListResponse;
+use KeepersTeam\Webtlo\Infrastructure\Database\ConnectionInterface;
 use KeepersTeam\Webtlo\Storage\Clone\KeepersLists;
 use KeepersTeam\Webtlo\Storage\Clone\KeepersSeeders;
 use KeepersTeam\Webtlo\Storage\Table\UpdateTime;
@@ -21,13 +22,14 @@ use Throwable;
 final class KeepersReports
 {
     public function __construct(
-        private readonly ApiReportClient $apiReport,
-        private readonly ReportSend      $configReport,
-        private readonly SubForums       $configSubForums,
-        private readonly KeepersLists    $keepersLists,
-        private readonly KeepersSeeders  $keepersSeeders,
-        private readonly UpdateTime      $updateTime,
-        private readonly LoggerInterface $logger,
+        private readonly ApiReportClient     $apiReport,
+        private readonly ReportSend          $configReport,
+        private readonly SubForums           $configSubForums,
+        private readonly KeepersLists        $keepersLists,
+        private readonly KeepersSeeders      $keepersSeeders,
+        private readonly UpdateTime          $updateTime,
+        private readonly ConnectionInterface $db,
+        private readonly LoggerInterface     $logger,
     ) {}
 
     public function __destruct()
@@ -55,14 +57,10 @@ final class KeepersReports
 
         // Список ид обновлений подразделов.
         $keptForumsUpdate = array_map(static fn($el) => 100000 + $el, $keptForums);
+        $keptForumsUpdate[] = UpdateMark::KEEPERS->value;
 
         $updateStatus = $this->updateTime->getMarkersObject(markers: $keptForumsUpdate);
         $updateStatus->checkMarkersLess(seconds: 15 * 60);
-
-        // Если количество маркеров не совпадает, обнулим имеющиеся, чтобы обновить все.
-        if ($updateStatus->getLastCheckStatus() === UpdateStatus::MISSED) {
-            $this->keepersLists->clearLists();
-        }
 
         // Проверим минимальную дату обновления данных других хранителей.
         if ($updateStatus->getLastCheckStatus() === UpdateStatus::EXPIRED) {
@@ -92,7 +90,6 @@ final class KeepersReports
         }
 
         $forumsScanned = 0;
-        $keeperIds     = [];
 
         $apiReportCount = 0;
 
@@ -114,50 +111,72 @@ final class KeepersReports
             Timers::start("get_report_api_$forumId");
 
             try {
+                $this->keepersLists->clearTempTable();
+                $this->keepersSeeders->clearTempTable();
+
                 $forumReports = $this->apiReport->getKeepersReports(forumId: $forumId);
+
+                $keeperIds = [];
+                foreach ($forumReports->keepers as $keeperReport) {
+                    // Пропускаем игнорируемых хранителей.
+                    if (in_array($keeperReport->keeperId, $excludedKeepers, true)) {
+                        continue;
+                    }
+
+                    /** Данные о хранителе. */
+                    $keeper = $keepersList->getKeeperInfo(keeperId: $keeperReport->keeperId);
+
+                    // Пропускаем раздачи несуществующих хранителей.
+                    if ($keeper === null) {
+                        continue;
+                    }
+
+                    // Записываем сидов-хранителей раздачи, не зависимо от статуса.
+                    $this->keepersSeeders->addKeptTopics(keeper: $keeper, topics: $keeperReport->topics);
+                    $this->keepersSeeders->cloneFill();
+
+                    // Пропускаем раздачи кандидатов в хранители.
+                    if ($keeper->isCandidate) {
+                        continue;
+                    }
+
+                    $keeperIds[] = $keeper->keeperId;
+                    $this->keepersLists->addKeptTopics(keeper: $keeper, topics: $keeperReport->topics);
+                    $this->keepersLists->fillTempTable();
+                }
             } catch (Throwable $e) {
-                $this->logger->warning($e->getMessage());
+                $this->logger->warning('Не удалось обработать отчёт подраздела {forum}: {error}', [
+                    'forum' => $forumId,
+                    'error' => $e->getMessage(),
+                ]);
 
                 continue;
             }
 
-            foreach ($forumReports->keepers as $keeperReport) {
-                // Пропускаем игнорируемых хранителей.
-                if (in_array($keeperReport->keeperId, $excludedKeepers, true)) {
-                    continue;
-                }
+            try {
+                $this->db->beginTransaction();
+                $listsCount = $this->keepersLists->replaceForum(forumId: $forumId);
+                $seedersCount = $this->keepersSeeders->replaceForum(forumId: $forumId);
+                $this->updateTime->setMarkerTime(marker: 100000 + $forumId);
+                $this->db->commitTransaction();
+            } catch (Throwable $e) {
+                $this->db->rollbackTransaction();
+                $this->logger->error('Не удалось записать отчёт подраздела {forum}: {error}', [
+                    'forum' => $forumId,
+                    'error' => $e->getMessage(),
+                ]);
 
-                /** Данные о хранителе. */
-                $keeper = $keepersList->getKeeperInfo(keeperId: $keeperReport->keeperId);
-
-                // Пропускаем раздачи несуществующих хранителей.
-                if ($keeper === null) {
-                    continue;
-                }
-
-                // Записываем сидов-хранителей раздачи, не зависимо от статуса.
-                $this->keepersSeeders->addKeptTopics(keeper: $keeper, topics: $keeperReport->topics);
-                // Запись сидов-хранителей во временную таблицу.
-                $this->keepersSeeders->cloneFill();
-
-                // Пропускаем раздачи кандидатов в хранители.
-                if ($keeper->isCandidate) {
-                    continue;
-                }
-
-                // Считаем уникальных хранителей.
-                $keeperIds[] = $keeper->keeperId;
-
-                // Записываем раздачи хранителя во временную таблицу.
-                $this->keepersLists->addKeptTopics(keeper: $keeper, topics: $keeperReport->topics);
-                $this->keepersLists->fillTempTable();
+                continue;
             }
 
-            // Считаем обновлённые подразделы.
             ++$forumsScanned;
 
-            // Пометим факт обновления отчётов хранителей подраздела.
-            $this->updateTime->setMarkerTime(marker: 100000 + $forumId);
+            $this->logger->info('ApiReport. Подраздел {forum}: хранителей {keepers}, записей {lists}, сидов {seeders}.', [
+                'forum'   => $forumId,
+                'keepers' => count(array_unique($keeperIds)),
+                'lists'   => $listsCount,
+                'seeders' => $seedersCount,
+            ]);
 
             $this->logger->debug('Отчёт получен [{current}/{total}] {sec}', [
                 'forumId' => $forumId,
@@ -174,23 +193,58 @@ final class KeepersReports
             );
         }
 
-        // Записываем изменения в локальную таблицу.
-        $this->keepersLists->moveToOrigin(
-            forumsScanned: $forumsScanned,
-            keepersCount : count(array_unique($keeperIds))
-        );
+        if ($forumsScanned !== $forumCount) {
+            $this->logger->warning('ApiReport. Обновлено {updated} из {total} подразделов.', [
+                'updated' => $forumsScanned,
+                'total'   => $forumCount,
+            ]);
 
-        // Записываем данные о сидах-хранителях в БД.
-        $this->keepersSeeders->moveToOrigin();
+            return false;
+        }
 
-        // Записываем дату получения списков.
-        $this->updateTime->setMarkerTime(marker: UpdateMark::KEEPERS);
+        try {
+            $this->db->beginTransaction();
+            $this->removeOrphanRows($keptForums);
+            $this->updateTime->setMarkerTime(marker: UpdateMark::KEEPERS);
+            $this->db->commitTransaction();
+        } catch (Throwable $e) {
+            $this->db->rollbackTransaction();
+            $this->logger->error('Не удалось завершить обновление отчётов хранителей: {error}', [
+                'error' => $e->getMessage(),
+            ]);
+
+            return false;
+        }
+
         $this->logger->info(
             'ApiReport. Обновление отчётов хранителей завершено за {sec}',
             ['sec' => Timers::getExecTime('update_keepers')]
         );
 
         return true;
+    }
+
+    /**
+     * Удалять сирот можно только после полного обновления отчётов и при наличии
+     * актуальных маркеров тем всех хранимых подразделов.
+     *
+     * @param int[] $keptForums
+     */
+    private function removeOrphanRows(array $keptForums): void
+    {
+        $topicsStatus = $this->updateTime->getMarkersObject(markers: $keptForums);
+        $topicsStatus->checkMarkersAbove(seconds: 5 * 24 * 3600);
+        if ($topicsStatus->getLastCheckStatus() !== null) {
+            $this->logger->debug('ApiReport. Очистка записей без темы отложена: данные подразделов неполные или устарели.');
+
+            return;
+        }
+
+        foreach ([KeepersLists::TABLE, KeepersSeeders::TABLE] as $table) {
+            $this->db->executeStatement(
+                "DELETE FROM $table WHERE NOT EXISTS (SELECT 1 FROM Topics WHERE Topics.id = $table.topic_id)"
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
## Что изменено

- Каждый отчёт подраздела полностью обрабатывается во временных таблицах до изменения основных данных.
- KeepersLists, KeepersSeeders и маркер подраздела обновляются одной транзакцией. Сбой одного подраздела сохраняет его прежние данные и не отменяет успешно обновлённые подразделы.
- Глобальная очистка заменена очисткой по текущему подразделу темы; устранено сравнение ключей через склейку topic_id и keeper_id.
- Общий маркер KEEPERS обновляется только после успешного прохода всех подразделов. Тогда же удаляются записи без темы, если маркеры обновления тем актуальны.

## Проверка

- Проверены 12 сценариев SQL на SQLite: изоляция подразделов, пустой отчёт, откат данных и маркера, очистка сирот.
- git diff --check — без замечаний.
- PHP и Composer в локальном окружении отсутствуют, поэтому PHP-CS-Fixer и PHPStan здесь не запускались; их результаты следует проверить в CI.